### PR TITLE
feat: パッチノートにLODESTONEスタイルのタブフィルタを追加

### DIFF
--- a/src/components/PatchNotesModal.tsx
+++ b/src/components/PatchNotesModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import type { PatchEntry, ChangeType } from "../data/patchNotes";
 import { patchNotes } from "../data/patchNotes";
 
@@ -111,7 +111,19 @@ function YearBlock({
   );
 }
 
+type TypeTab = "all" | ChangeType;
+
+const TYPE_TABS: { id: TypeTab; label: string }[] = [
+  { id: "all", label: "全て" },
+  { id: "feature", label: badgeLabel.feature },
+  { id: "fix", label: badgeLabel.fix },
+  { id: "improve", label: badgeLabel.improve },
+];
+
 export function PatchNotesModal({ onClose }: { onClose: () => void }) {
+  const [typeTab, setTypeTab] = useState<TypeTab>("all");
+  const [yearTab, setYearTab] = useState<string>("all");
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -120,7 +132,38 @@ export function PatchNotesModal({ onClose }: { onClose: () => void }) {
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  const grouped = groupByYearMonth(patchNotes);
+  // タイプでフィルタ（変更を絞り込み）
+  const typeFiltered =
+    typeTab === "all"
+      ? patchNotes
+      : patchNotes
+          .map((entry) => ({
+            ...entry,
+            changes: entry.changes.filter((c) => c.type === typeTab),
+          }))
+          .filter((entry) => entry.changes.length > 0);
+
+  // 利用可能な年一覧（タイプフィルタ後）
+  const availableYears = [
+    ...new Set(typeFiltered.map((e) => e.date.split("-")[0])),
+  ].sort().reverse();
+
+  // yearTabが無効になった場合は "all" にフォールバック
+  const effectiveYearTab =
+    yearTab === "all" || availableYears.includes(yearTab) ? yearTab : "all";
+
+  // 年でフィルタ
+  const filtered =
+    effectiveYearTab === "all"
+      ? typeFiltered
+      : typeFiltered.filter((e) => e.date.startsWith(effectiveYearTab));
+
+  const grouped = groupByYearMonth(filtered);
+
+  const handleTypeTab = (tab: TypeTab) => {
+    setTypeTab(tab);
+    setYearTab("all");
+  };
 
   return (
     <div
@@ -142,16 +185,82 @@ export function PatchNotesModal({ onClose }: { onClose: () => void }) {
           </button>
         </div>
 
+        {/* タイプタブ（1段目・LODESTONEスタイル） */}
+        <div className="border-b border-gray-200 shrink-0">
+          <div className="flex -mb-px px-2">
+            {TYPE_TABS.map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => handleTypeTab(id)}
+                className={`px-4 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                  typeTab === id
+                    ? "border-amber-500 text-amber-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 年タブ（2段目・ピル型、年が複数ある時のみ表示） */}
+        {availableYears.length > 1 && (
+          <div className="flex items-center gap-1.5 px-4 py-2 border-b border-gray-100 shrink-0 flex-wrap">
+            <button
+              onClick={() => setYearTab("all")}
+              className={`px-2.5 py-0.5 text-xs rounded-full font-medium transition-colors ${
+                effectiveYearTab === "all"
+                  ? "bg-gray-700 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+            >
+              全期間
+            </button>
+            {availableYears.map((year) => (
+              <button
+                key={year}
+                onClick={() => setYearTab(year)}
+                className={`px-2.5 py-0.5 text-xs rounded-full font-medium transition-colors ${
+                  effectiveYearTab === year
+                    ? "bg-gray-700 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {year}年
+              </button>
+            ))}
+          </div>
+        )}
+
         {/* エントリリスト */}
         <div className="overflow-y-auto flex-1">
-          {[...grouped.entries()].map(([year, monthMap], i) => (
-            <YearBlock
-              key={year}
-              year={year}
-              monthMap={monthMap}
-              defaultOpen={i === 0}
-            />
-          ))}
+          {filtered.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-gray-400">
+              該当する更新はありません
+            </div>
+          ) : effectiveYearTab === "all" ? (
+            [...grouped.entries()].map(([year, monthMap], i) => (
+              <YearBlock
+                key={year}
+                year={year}
+                monthMap={monthMap}
+                defaultOpen={i === 0}
+              />
+            ))
+          ) : (
+            // 特定年選択時は月単位から表示（年ヘッダーは省略）
+            [...grouped.values()].flatMap((monthMap) =>
+              [...monthMap.entries()].map(([month, entries], i) => (
+                <MonthBlock
+                  key={month}
+                  month={month}
+                  entries={entries}
+                  defaultOpen={i === 0}
+                />
+              ))
+            )
+          )}
         </div>
 
         {/* フッター */}


### PR DESCRIPTION
## Summary
- 変更タイプ（全て / 追加 / 修正 / 改善）でフィルタする下線タブを追加（LODESTONEスタイル）
- 年フィルタのピル型タブを2段目に追加（年が複数ある場合のみ表示）
- タイプ切替時に年タブを自動リセット、該当データなし時は空状態を表示

## Test plan
- [x] 各タイプタブ（全て/追加/修正/改善）の切替でエントリが正しく絞り込まれる
- [ ] 年タブが複数年存在する場合のみ2段目に表示される
- [x] タイプ切替時に年タブが「全期間」にリセットされる
- [x] 特定年選択時に年ヘッダーが省略されて月から表示される
- [ ] 該当なしの場合に「該当する更新はありません」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)