### PR TITLE
fix: パッチノートワークフローにPATを使用してブランチ保護をバイパス

### DIFF
--- a/.github/workflows/update-patchnotes.yml
+++ b/.github/workflows/update-patchnotes.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # git log を全件取得するため
+          token: ${{ secrets.PATCH_NOTES_PAT }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- checkoutステップに`PATCH_NOTES_PAT`を追加し、github-actions[bot]の直接pushがブランチ保護ルールに弾かれる問題を修正

## Test plan
- [ ] マージ後にUpdate Patch Notesワークフローを手動実行しエラーなく完了することを確認