### PR TITLE
feat: 魔法無効エネミーの表示対応

### DIFF
--- a/docs/data/monsters.json
+++ b/docs/data/monsters.json
@@ -2003,7 +2003,8 @@
     "mov": 22,
     "captureRate": 0.1,
     "exp": 36,
-    "gold": 20000
+    "gold": 20000,
+    "magicImmune": true
   },
   {
     "name": "トリカゴドリ",
@@ -2054,7 +2055,8 @@
     "mov": 0,
     "captureRate": 0.1,
     "exp": 621200,
-    "gold": 220000
+    "gold": 220000,
+    "magicImmune": true
   },
   {
     "name": "オコォーン",

--- a/src/components/DamageCalculator.tsx
+++ b/src/components/DamageCalculator.tsx
@@ -1182,6 +1182,9 @@ export function DamageCalculator() {
             <span className="text-sm bg-gray-100 text-gray-600 px-2 py-0.5 rounded-lg font-medium">Lv{monsterLevel.toLocaleString()}</span>
             <span className={`text-sm px-2 py-0.5 rounded-lg border font-medium ${elementColors[scaled.element]}`}>{t(`game:element.${scaled.element}`)}</span>
             <span className="text-sm bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded-lg font-medium">{t(`game:attackType.${scaled.attackType}`)}</span>
+            {scaled.magicImmune && (
+              <span className="text-sm px-2 py-0.5 rounded-lg font-bold bg-purple-100 text-purple-600 border border-purple-200">魔法無効</span>
+            )}
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-2">
             <div className="flex flex-col">
@@ -1255,9 +1258,17 @@ export function DamageCalculator() {
                     {selfToEnemyAffinity > 1 ? `${t("weakness")} ×1.2` : selfToEnemyAffinity < 1 ? `${t("resistance")} ×0.8` : `${t("normal")} ×1.0`}
                   </span>
                 </div>
+                {scaled!.magicImmune && (
+                  <div className="flex items-center gap-2 px-3 py-2 mb-2 rounded-xl bg-purple-50 border border-purple-200">
+                    <span className="text-purple-500 text-base">🚫</span>
+                    <span className="text-sm font-bold text-purple-700">この敵は魔法が無効です（ダメージ 0）</span>
+                  </div>
+                )}
                 {hasMyOffenseStats ? (
                   <div className="grid grid-cols-[1fr_auto_auto_auto] gap-y-1.5 gap-x-1">
-                    {offensiveResult.spellResults.map(({ spell, dmg, totalMin, totalMax, hitsToKill, overkillGuaranteed, overkillPossible, overkillStatNeeded, overkillCubesNeeded }) => (
+                    {offensiveResult.spellResults.map(({ spell, dmg, totalMin, totalMax, hitsToKill, overkillGuaranteed, overkillPossible, overkillStatNeeded, overkillCubesNeeded }) => {
+                      const effectivelyNullified = dmg.isNullified || !!scaled!.magicImmune;
+                      return (
                       <div key={spell.name} className="col-span-4 grid grid-cols-subgrid bg-white/60 rounded-lg py-1.5">
                         <div className="col-span-4 flex items-center gap-1 mb-1 px-2">
                           <span className={`text-xs px-1 py-0.5 rounded border font-medium ${elementColors[spell.element]}`}>{t(`game:element.${spell.element}`)}</span>
@@ -1265,14 +1276,14 @@ export function DamageCalculator() {
                           <span className="text-xs text-gray-400">
                             ×{spell.multiplier}{spell.hits > 1 ? ` / ${spell.hits}${t("hits")}` : ""}
                           </span>
-                          {!dmg.isNullified && (overkillGuaranteed || overkillPossible) && (
+                          {!effectivelyNullified && (overkillGuaranteed || overkillPossible) && (
                             <span className={`text-xs px-1.5 py-0.5 rounded-full font-bold tracking-wide ${
                               overkillGuaranteed ? "bg-orange-500 text-white" : "bg-orange-100 text-orange-600"
                             }`}>
                               {overkillGuaranteed ? "OVERKILL!" : "OVERKILL?"}
                             </span>
                           )}
-                          {!dmg.isNullified && (
+                          {!effectivelyNullified && (
                             <span className={`ml-auto text-sm font-bold px-2 py-0.5 rounded-full ${
                               hitsToKill === 1 ? "bg-green-100 text-green-700" :
                               hitsToKill <= 3 ? "bg-yellow-100 text-yellow-700" :
@@ -1282,8 +1293,10 @@ export function DamageCalculator() {
                             </span>
                           )}
                         </div>
-                        {dmg.isNullified ? (
-                          <span className="col-span-4 text-xs text-gray-400 px-2">{t("cannotPenetrate")}</span>
+                        {effectivelyNullified ? (
+                          <span className="col-span-4 text-xs text-purple-500 font-semibold px-2">
+                            {scaled!.magicImmune ? "魔法無効（ダメージ 0）" : t("cannotPenetrate")}
+                          </span>
                         ) : (
                           <>
                             <span className="pl-2 text-sm font-bold text-green-600 tabular-nums text-right self-center">{totalMin.toLocaleString()}</span>
@@ -1291,7 +1304,7 @@ export function DamageCalculator() {
                             <span className="pr-2 text-sm font-bold text-green-600 tabular-nums text-right self-center">{totalMax.toLocaleString()}</span>
                           </>
                         )}
-                        {!dmg.isNullified && (
+                        {!effectivelyNullified && (
                           <div className="col-span-4 flex flex-col items-end gap-0.5 px-2 pt-0.5">
                             <div className="flex items-center gap-1">
                               {overkillGuaranteed ? (
@@ -1323,7 +1336,7 @@ export function DamageCalculator() {
                           </div>
                         )}
                       </div>
-                    ))}
+                    ); })}
                   </div>
                 ) : (
                   <p className="text-xs text-gray-400">{t("enterIntForDamage")}</p>

--- a/src/components/ui/EnemyPresetModal.tsx
+++ b/src/components/ui/EnemyPresetModal.tsx
@@ -175,7 +175,12 @@ export function EnemyPresetModal({
                         )}
                       </span>
                     )}
-                    <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700">{preset.monsterName ?? t("game:unknownName")}</span>
+                    <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 flex items-center gap-1.5">
+                      {preset.monsterName ?? t("game:unknownName")}
+                      {preset.magicImmune && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-600 font-bold flex-shrink-0">魔法無効</span>
+                      )}
+                    </span>
                     <span className="w-28 text-right text-sm font-mono font-semibold text-indigo-600">{preset.level.toLocaleString()}</span>
                     <span className="w-44 text-right text-sm text-gray-700">{preset.location}</span>
                   </div>
@@ -194,7 +199,12 @@ export function EnemyPresetModal({
                       </span>
                     )}
                     <div className="min-w-0 flex-1">
-                      <div className="font-semibold text-gray-900 text-sm group-hover:text-indigo-700">{preset.monsterName ?? t("game:unknownName")}</div>
+                      <div className="font-semibold text-gray-900 text-sm group-hover:text-indigo-700 flex items-center gap-1.5">
+                        {preset.monsterName ?? t("game:unknownName")}
+                        {preset.magicImmune && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-600 font-bold flex-shrink-0">魔法無効</span>
+                        )}
+                      </div>
                       <div className="flex items-center gap-2 mt-0.5">
                         <span className="text-xs font-mono font-semibold text-indigo-600">Lv {preset.level.toLocaleString()}</span>
                         <span className="text-xs text-gray-500">{preset.location}</span>

--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -2,6 +2,7 @@ export interface EnemyPreset {
   monsterName: string | null; // null = 名称不明
   level: number;
   location: string;
+  magicImmune?: boolean;
 }
 
 export interface EnemyPresetGroup {
@@ -44,7 +45,7 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
       { monsterName: "残燃モエコ",         level: 95000,  location: "循環宇宙３・右" },
       { monsterName: "ドラゴンヘッド",     level: 95000,  location: "循環宇宙３・右" },
       { monsterName: "ラッキーヒトデ",     level: 98000,  location: "循環宇宙３・下" },
-      { monsterName: "動く石碑",           level: 98000,  location: "循環宇宙３・下・レア出現" },
+      { monsterName: "動く石碑",           level: 98000,  location: "循環宇宙３・下・レア出現", magicImmune: true },
       { monsterName: "捧げし者",           level: 144444, location: "循環宇宙３・右下" },
       { monsterName: "黎明神トモダチ",     level: 144444, location: "循環宇宙３・右下" },
     ],
@@ -72,9 +73,9 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
       { monsterName: "黙示木",             level: 390000, location: "循環宇宙最深部・左右の小部屋" },
       { monsterName: "雷大王イカ",         level: 390000, location: "循環宇宙最深部・左右の小部屋" },
       { monsterName: "グラビティスライム", level: 390000, location: "循環宇宙最深部・左右の小部屋" },
-      { monsterName: "動く石碑",           level: 310000, location: "循環宇宙最深部・レア出現" },
-      { monsterName: "動く石碑",           level: 365000, location: "循環宇宙最深部・レア出現" },
-      { monsterName: "動く石碑",           level: 390000, location: "循環宇宙最深部・レア出現" },
+      { monsterName: "動く石碑",           level: 310000, location: "循環宇宙最深部・レア出現", magicImmune: true },
+      { monsterName: "動く石碑",           level: 365000, location: "循環宇宙最深部・レア出現", magicImmune: true },
+      { monsterName: "動く石碑",           level: 390000, location: "循環宇宙最深部・レア出現", magicImmune: true },
       { monsterName: "ドラゴンヘッド",     level: 580000, location: "循環宇宙最深部・ボス部屋" },
       { monsterName: "黙示木",             level: 650000, location: "循環宇宙最深部・ボス部屋" },
       { monsterName: "鉄壁要塞パルテノン", level: 680000, location: "循環宇宙最深部・ボス" },
@@ -119,7 +120,7 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
       { monsterName: "オコスター",       level: 350000,   location: "太古の中庭" },
       { monsterName: "オコォーン",       level: 350000,   location: "太古の中庭・レア出現" },
       { monsterName: "黙示木",           level: 810000,   location: "太古の中庭" },
-      { monsterName: "根界獣ドルグラント", level: 1280000, location: "太古の中庭・ボス" },
+      { monsterName: "根界獣ドルグラント", level: 1280000, location: "太古の中庭・ボス", magicImmune: true },
     ],
   },
   // ---- 深淵回廊 ----

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -19,6 +19,7 @@ export interface MonsterBase {
   captureRate: number;
   exp: number;
   gold: number;
+  magicImmune?: boolean;
 }
 
 export interface ScaledMonster extends MonsterBase {


### PR DESCRIPTION
## 変更内容

Issue #93 の対応。動く石碑・根界獣ドルグラントは受ける魔法ダメージが0になる特殊効果を持つため、ダメージ計算シミュとプリセット一覧にその情報を表示するようにした。

### 変更ファイル

- **`docs/data/monsters.json`**: index 117（動く石碑）・index 120（根界獣ドルグラント）に `"magicImmune": true` を追加（末尾フィールド追加のみ・インデックス変更なし）
- **`src/types/game.ts`**: `MonsterBase` 型に `magicImmune?: boolean` を追加
- **`src/data/enemyPresets.ts`**: `EnemyPreset` 型に `magicImmune?: boolean` を追加し、対象の全プリセットエントリ（動く石碑 ×4、根界獣ドルグラント ×1）に付与
- **`src/components/ui/EnemyPresetModal.tsx`**: `magicImmune: true` のプリセットに「魔法無効」バッジを表示
- **`src/components/DamageCalculator.tsx`**:
  - 敵ステータス表示欄に「魔法無効」バッジを追加
  - 魔攻モード時に「この敵は魔法が無効です（ダメージ 0）」警告バナーを表示
  - 各魔法呪文の結果を「魔法無効（ダメージ 0）」として表示し、確殺・Overkill情報を非表示にする

## 対応 Issue

close #93

## 確認事項

- [x] 動く石碑のプリセットを選択したとき、モーダル内に「魔法無効」バッジが表示される
- [x] 動く石碑を選択した状態で魔攻モードにすると、警告バナーが表示され各魔法が「魔法無効（ダメージ 0）」と表示される
- [x] 根界獣ドルグラント（太古の中庭ボス）でも同様に動作する
- [ ] 物理攻撃の計算結果・被ダメージ計算には影響がない
- [x] monsters.json のインデックスが変わっていない（既存の共有URLが壊れない）
- [ ] `npx tsc --noEmit` エラーなし
- [ ] `npm run build` 成功