### PR TITLE
feat: ペットシミュレータタブを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { FarmCalculator } from "./components/FarmCalculator";
 import { StatusSimulator } from "./components/StatusSimulator";
 import { ArenaCalculator } from "./components/ArenaCalculator";
 import { MonsterEditor } from "./components/MonsterEditor";
+import { PetSimulator } from "./components/PetSimulator";
 import { TabNav, type Tab } from "./components/ui/TabNav";
 import { PatchNotesModal } from "./components/PatchNotesModal";
 
@@ -15,6 +16,7 @@ function App() {
     { id: "damage", label: t("tabs.damage"), shortLabel: t("tabs.damageShort"), icon: "⚔" },
     { id: "arena", label: t("tabs.arena"), icon: "🏟" },
     { id: "status", label: t("tabs.status"), shortLabel: t("tabs.statusShort"), icon: "✦" },
+    { id: "pet", label: t("tabs.pet"), shortLabel: t("tabs.petShort"), icon: "🐾" },
     { id: "farm", label: t("tabs.farm"), shortLabel: t("tabs.farmShort"), icon: "♻" },
     { id: "monsters", label: t("tabs.monsters"), shortLabel: t("tabs.monstersShort"), icon: "📋" },
   ];
@@ -136,6 +138,9 @@ function App() {
         </div>
         <div className={activeTab === "arena" ? "" : "hidden"}>
           <ArenaCalculator />
+        </div>
+        <div className={activeTab === "pet" ? "" : "hidden"}>
+          <PetSimulator />
         </div>
         <div className={activeTab === "monsters" ? "" : "hidden"}>
           <MonsterEditor />

--- a/src/components/PetSimulator.tsx
+++ b/src/components/PetSimulator.tsx
@@ -1,0 +1,289 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { usePersistedState, usePersistedGroup } from "../hooks/usePersistedState";
+import { calcPetStats, findEquivalentLevels, DEFAULT_PET_DAMAGE_CONFIG } from "../utils/petStatCalc";
+import type { PetDamageConfig } from "../types/game";
+import { useAllMonsters } from "../hooks/useAllMonsters";
+import { PetConfigPanel } from "./damage/PetConfigPanel";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const STAT_DISPLAY = [
+  { key: "vit" as const, label: "VIT" },
+  { key: "spd" as const, label: "SPD" },
+  { key: "atk" as const, label: "ATK" },
+  { key: "int" as const, label: "INT" },
+  { key: "def" as const, label: "DEF" },
+  { key: "mdef" as const, label: "M-DEF" },
+  { key: "luck" as const, label: "LUCK" },
+];
+
+// ── Comparison Table ──────────────────────────────────────────────────────────
+
+type StatKey = typeof STAT_DISPLAY[number]["key"];
+
+function PetCompareTable({
+  resultA,
+  resultB,
+}: {
+  resultA: ReturnType<typeof calcPetStats>;
+  resultB: ReturnType<typeof calcPetStats>;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="bg-gray-50 text-xs text-gray-500">
+            <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">設定 A</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">設定 B</th>
+            <th className="text-right px-3 py-2 border border-gray-100">差分</th>
+          </tr>
+        </thead>
+        <tbody>
+          {STAT_DISPLAY.map(({ key, label }) => {
+            const a = resultA.final[key];
+            const b = resultB.final[key];
+            const diff = b - a;
+            return (
+              <tr key={key} className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600 sticky left-0 bg-white group-even:bg-gray-50/50 group-hover:bg-gray-100/50 z-10">{label}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{a.toLocaleString()}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-orange-600 font-medium">{b.toLocaleString()}</td>
+                <td className={`px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold ${diff > 0 ? "text-green-600" : diff < 0 ? "text-red-500" : "text-gray-400"}`}>
+                  {diff > 0 ? `+${diff.toLocaleString()}` : diff.toLocaleString()}
+                </td>
+              </tr>
+            );
+          })}
+          {(() => {
+            const diff = resultB.hp - resultA.hp;
+            return (
+              <tr className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                <td className="px-3 py-1.5 border border-gray-100 font-medium text-red-600 sticky left-0 bg-white z-10">HP</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{resultA.hp.toLocaleString()}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-orange-600 font-medium">{resultB.hp.toLocaleString()}</td>
+                <td className={`px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold ${diff > 0 ? "text-green-600" : diff < 0 ? "text-red-500" : "text-gray-400"}`}>
+                  {diff > 0 ? `+${diff.toLocaleString()}` : diff.toLocaleString()}
+                </td>
+              </tr>
+            );
+          })()}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Equivalent Level Table ────────────────────────────────────────────────────
+
+function EquivalentLevelTable({
+  resultA,
+  eqLevels,
+  currentLevelB,
+}: {
+  resultA: ReturnType<typeof calcPetStats>;
+  eqLevels: Record<StatKey, number | null>;
+  currentLevelB: number;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-500">
+        設定 A の各ステータスに、設定 B が追いつく最低レベル
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-gray-50 text-xs text-gray-500">
+              <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">A の値</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">B の追いつきLv</th>
+            </tr>
+          </thead>
+          <tbody>
+            {STAT_DISPLAY.map(({ key, label }) => {
+              const eqLv = eqLevels[key];
+              const targetVal = resultA.final[key];
+              const isAlreadyAchieved = eqLv !== null && eqLv <= currentLevelB;
+              return (
+                <tr key={key} className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                  <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600 sticky left-0 bg-white group-even:bg-gray-50/50 group-hover:bg-gray-100/50 z-10">{label}</td>
+                  <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{targetVal.toLocaleString()}</td>
+                  <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold">
+                    {eqLv === null ? (
+                      <span className="text-red-400">Lv.1200でも届かない</span>
+                    ) : isAlreadyAchieved ? (
+                      <span className="text-green-600">達成済み (Lv.{eqLv.toLocaleString()})</span>
+                    ) : (
+                      <span className="text-orange-600">Lv.{eqLv.toLocaleString()}</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Single Stat Panel ─────────────────────────────────────────────────────────
+
+function PetStatPanel({ result, label }: { result: ReturnType<typeof calcPetStats>; label: string }) {
+  const { t: tGame } = useTranslation("game");
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <p className="text-xs font-semibold text-gray-500">{label}</p>
+        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600">
+          {tGame(`element.${result.element}`)} / {tGame(`attackType.${result.attackMode}`)}
+        </span>
+      </div>
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="bg-gray-50 text-xs text-gray-500">
+            <th className="text-left px-3 py-2 border border-gray-100">ステータス</th>
+            <th className="text-right px-3 py-2 border border-gray-100">値</th>
+          </tr>
+        </thead>
+        <tbody>
+          {STAT_DISPLAY.map(({ key, label: statLabel }) => (
+            <tr key={key} className="even:bg-gray-50/50">
+              <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600">{statLabel}</td>
+              <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold text-blue-700">{result.final[key].toLocaleString()}</td>
+            </tr>
+          ))}
+          <tr className="bg-red-50/60">
+            <td className="px-3 py-1.5 border border-gray-100 font-medium text-red-600">HP</td>
+            <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold text-red-600">{result.hp.toLocaleString()}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export function PetSimulator() {
+  type PetCfgTuple = [PetDamageConfig, <K extends keyof PetDamageConfig>(field: K, value: PetDamageConfig[K]) => void, () => void, (s: PetDamageConfig) => void];
+  const [cfgA, setFieldA, resetA, replaceAllA] = usePersistedGroup<PetDamageConfig & Record<string, unknown>>(
+    "pet-sim:a",
+    DEFAULT_PET_DAMAGE_CONFIG as PetDamageConfig & Record<string, unknown>,
+  ) as unknown as PetCfgTuple;
+  const [cfgB, setFieldB, resetB, replaceAllB] = usePersistedGroup<PetDamageConfig & Record<string, unknown>>(
+    "pet-sim:b",
+    DEFAULT_PET_DAMAGE_CONFIG as PetDamageConfig & Record<string, unknown>,
+  ) as unknown as PetCfgTuple;
+  const [activeConfig, setActiveConfig] = usePersistedState<"A" | "B">("pet-sim:active", "A");
+
+  const allMonsters = useAllMonsters();
+
+  const monsterA = useMemo(
+    () => (cfgA.petMonsterName ? allMonsters.find((m) => m.name === cfgA.petMonsterName) ?? null : null),
+    [cfgA.petMonsterName, allMonsters],
+  );
+  const monsterB = useMemo(
+    () => (cfgB.petMonsterName ? allMonsters.find((m) => m.name === cfgB.petMonsterName) ?? null : null),
+    [cfgB.petMonsterName, allMonsters],
+  );
+
+  const resultA = useMemo(() => (monsterA ? calcPetStats(cfgA, monsterA) : null), [cfgA, monsterA]);
+  const resultB = useMemo(() => (monsterB ? calcPetStats(cfgB, monsterB) : null), [cfgB, monsterB]);
+
+  const eqLevels = useMemo(() => {
+    if (!resultA || !monsterB) return null;
+    return findEquivalentLevels(resultA, cfgB, monsterB);
+  }, [resultA, cfgB, monsterB]);
+
+  const activeCfg = activeConfig === "A" ? cfgA : cfgB;
+  const activeSetField = activeConfig === "A" ? setFieldA : setFieldB;
+  const activeReset = activeConfig === "A" ? resetA : resetB;
+  const activeReplaceAll = activeConfig === "A" ? replaceAllA : replaceAllB;
+  const activeResult = activeConfig === "A" ? resultA : resultB;
+
+  const showCompare = resultA !== null && resultB !== null;
+  const showEqLevels = resultA !== null && resultB !== null && eqLevels !== null;
+
+  return (
+    <div className="lg:grid lg:grid-cols-[minmax(340px,400px)_1fr] lg:gap-6">
+      {/* 左パネル（入力） */}
+      <div className="space-y-4">
+        {/* A/B 設定タブ */}
+        <div className="flex rounded-xl overflow-hidden border border-gray-200">
+          {(["A", "B"] as const).map((id) => (
+            <button
+              key={id}
+              onClick={() => setActiveConfig(id)}
+              className={`flex-1 py-2 text-sm font-semibold transition-colors ${
+                activeConfig === id
+                  ? id === "A"
+                    ? "bg-blue-500 text-white"
+                    : "bg-orange-400 text-white"
+                  : "bg-white text-gray-500 hover:bg-gray-50"
+              }`}
+            >
+              設定 {id}
+            </button>
+          ))}
+        </div>
+
+        <PetConfigPanel
+          config={activeCfg}
+          setField={activeSetField}
+          reset={activeReset}
+          petResult={activeResult}
+          replaceConfig={activeReplaceAll}
+        />
+      </div>
+
+      {/* 右パネル（結果） */}
+      <div className="mt-6 lg:mt-0 space-y-4">
+        {showCompare ? (
+          <>
+            {/* 比較テーブル */}
+            <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+              <h2 className="text-base font-bold text-gray-700">ステータス比較</h2>
+              <PetCompareTable resultA={resultA} resultB={resultB} />
+            </div>
+
+            {/* 追いつきレベル */}
+            {showEqLevels && (
+              <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+                <h2 className="text-base font-bold text-gray-700">追いつきレベル（A→B）</h2>
+                <EquivalentLevelTable
+                  resultA={resultA}
+                  eqLevels={eqLevels}
+                  currentLevelB={cfgB.petLevel}
+                />
+              </div>
+            )}
+
+            {/* 個別詳細（比較中も表示） */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="bg-blue-50 rounded-xl border border-blue-100 p-4">
+                <PetStatPanel result={resultA} label="設定 A の詳細" />
+              </div>
+              <div className="bg-orange-50 rounded-xl border border-orange-100 p-4">
+                <PetStatPanel result={resultB} label="設定 B の詳細" />
+              </div>
+            </div>
+          </>
+        ) : activeResult ? (
+          /* 片方のみ設定済み */
+          <div className="bg-white rounded-xl border border-gray-200 p-4">
+            <PetStatPanel
+              result={activeResult}
+              label={`設定 ${activeConfig} のステータス`}
+            />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
+            ペットを選択してください
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -11,7 +11,9 @@
     "farm": "Farming",
     "farmShort": "Farm",
     "monsters": "Monster Editor",
-    "monstersShort": "MON"
+    "monstersShort": "MON",
+    "pet": "Pet Sim",
+    "petShort": "Pet"
   },
   "preparing": "Coming Soon",
   "add": "Add",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -11,7 +11,9 @@
     "farm": "周回計算",
     "farmShort": "周回計",
     "monsters": "モンスター登録",
-    "monstersShort": "図鑑"
+    "monstersShort": "図鑑",
+    "pet": "ペットシミュ",
+    "petShort": "ペット"
   },
   "preparing": "準備中",
   "add": "追加",

--- a/src/utils/petStatCalc.ts
+++ b/src/utils/petStatCalc.ts
@@ -78,6 +78,39 @@ function findHighestStatKey(
   return bestKey;
 }
 
+/**
+ * For each stat, find the minimum level for petB config to reach or exceed resultA's stat value.
+ * Returns null for a stat if even level 1200 cannot reach the target.
+ */
+export function findEquivalentLevels(
+  resultA: PetStatResult,
+  cfgB: PetDamageConfig,
+  monsterB: MonsterBase,
+): Record<StatKey, number | null> {
+  const result = {} as Record<StatKey, number | null>;
+  const maxResult = calcPetStats({ ...cfgB, petLevel: 1200 }, monsterB);
+
+  for (const key of STAT_KEYS) {
+    const targetStat = resultA.final[key];
+    if (maxResult.final[key] < targetStat) {
+      result[key] = null;
+      continue;
+    }
+    let lo = 1, hi = 1200;
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const midResult = calcPetStats({ ...cfgB, petLevel: mid }, monsterB);
+      if (midResult.final[key] >= targetStat) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    result[key] = lo;
+  }
+  return result;
+}
+
 export function calcPetStats(config: PetDamageConfig, monsterBase: MonsterBase): PetStatResult {
   const maxLevel = 1200;
   const level = Math.min(config.petLevel, maxLevel);


### PR DESCRIPTION
## 変更内容

### 新機能: ペットシミュレータ（🐾 タブ）

ペットの2つの設定（殲儀回数・レベル・粉・キノコ）を比較できる新しいタブを追加。

#### 主な機能
- **設定 A / B の切り替え入力**：StatusSimulator と同じ A/B タブ方式でペット設定を入力
- **ステータス比較テーブル**：A と B の全ステータスを並べて差分を表示
- **追いつきレベル計算**：「設定 A のレベル1200・10殲儀に、30殲儀の設定 B が追いつくには何レベル必要か」を各ステータスごとに二分探索で算出

#### 実装詳細
- `petStatCalc.ts` に `findEquivalentLevels()` を追加（全ステータスの追いつきレベルを一括計算）
- `PetSimulator.tsx` を新規作成（既存の `PetConfigPanel` を再利用）
- `App.tsx` に `🐾 ペットシミュ` タブを追加（ステータスタブとファームタブの間）
- 翻訳ファイル（ja/en）に新タブ名を追加

## 確認事項
- [x] TypeScript 型エラーなし（`npx tsc --noEmit`）
- [x] ビルド成功（`npm run build`）
- [x] 既存の PetConfigPanel・calcPetStats を破壊的変更なく再利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)