### PR TITLE
refactor: ヘッダータブを5個に整理（⋯ドロップダウン追加）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,8 +17,8 @@ function App() {
     { id: "arena", label: t("tabs.arena"), icon: "🏟" },
     { id: "status", label: t("tabs.status"), shortLabel: t("tabs.statusShort"), icon: "✦" },
     { id: "pet", label: t("tabs.pet"), shortLabel: t("tabs.petShort"), icon: "🐾" },
-    { id: "farm", label: t("tabs.farm"), shortLabel: t("tabs.farmShort"), icon: "♻" },
-    { id: "monsters", label: t("tabs.monsters"), shortLabel: t("tabs.monstersShort"), icon: "📋" },
+    { id: "farm", label: t("tabs.farm"), shortLabel: t("tabs.farmShort"), icon: "♻", overflow: true },
+    { id: "monsters", label: t("tabs.monsters"), shortLabel: t("tabs.monstersShort"), icon: "📋", overflow: true },
   ];
 
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { FarmCalculator } from "./components/FarmCalculator";
 import { StatusSimulator } from "./components/StatusSimulator";
 import { ArenaCalculator } from "./components/ArenaCalculator";
 import { MonsterEditor } from "./components/MonsterEditor";
+import { PetSimulator } from "./components/PetSimulator";
 import { TabNav, type Tab } from "./components/ui/TabNav";
 import { PatchNotesModal } from "./components/PatchNotesModal";
 
@@ -15,6 +16,7 @@ function App() {
     { id: "damage", label: t("tabs.damage"), shortLabel: t("tabs.damageShort"), icon: "⚔" },
     { id: "arena", label: t("tabs.arena"), icon: "🏟" },
     { id: "status", label: t("tabs.status"), shortLabel: t("tabs.statusShort"), icon: "✦" },
+    { id: "pet", label: t("tabs.pet"), shortLabel: t("tabs.petShort"), icon: "🐾" },
     { id: "farm", label: t("tabs.farm"), shortLabel: t("tabs.farmShort"), icon: "♻" },
     { id: "monsters", label: t("tabs.monsters"), shortLabel: t("tabs.monstersShort"), icon: "📋" },
   ];
@@ -136,6 +138,9 @@ function App() {
         </div>
         <div className={activeTab === "arena" ? "" : "hidden"}>
           <ArenaCalculator />
+        </div>
+        <div className={activeTab === "pet" ? "" : "hidden"}>
+          <PetSimulator />
         </div>
         <div className={activeTab === "monsters" ? "" : "hidden"}>
           <MonsterEditor />

--- a/src/components/PetSimulator.tsx
+++ b/src/components/PetSimulator.tsx
@@ -1,0 +1,289 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { usePersistedState, usePersistedGroup } from "../hooks/usePersistedState";
+import { calcPetStats, findEquivalentLevels, DEFAULT_PET_DAMAGE_CONFIG } from "../utils/petStatCalc";
+import type { PetDamageConfig } from "../types/game";
+import { useAllMonsters } from "../hooks/useAllMonsters";
+import { PetConfigPanel } from "./damage/PetConfigPanel";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const STAT_DISPLAY = [
+  { key: "vit" as const, label: "VIT" },
+  { key: "spd" as const, label: "SPD" },
+  { key: "atk" as const, label: "ATK" },
+  { key: "int" as const, label: "INT" },
+  { key: "def" as const, label: "DEF" },
+  { key: "mdef" as const, label: "M-DEF" },
+  { key: "luck" as const, label: "LUCK" },
+];
+
+// ── Comparison Table ──────────────────────────────────────────────────────────
+
+type StatKey = typeof STAT_DISPLAY[number]["key"];
+
+function PetCompareTable({
+  resultA,
+  resultB,
+}: {
+  resultA: ReturnType<typeof calcPetStats>;
+  resultB: ReturnType<typeof calcPetStats>;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="bg-gray-50 text-xs text-gray-500">
+            <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">設定 A</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">設定 B</th>
+            <th className="text-right px-3 py-2 border border-gray-100">差分</th>
+          </tr>
+        </thead>
+        <tbody>
+          {STAT_DISPLAY.map(({ key, label }) => {
+            const a = resultA.final[key];
+            const b = resultB.final[key];
+            const diff = b - a;
+            return (
+              <tr key={key} className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600 sticky left-0 bg-white group-even:bg-gray-50/50 group-hover:bg-gray-100/50 z-10">{label}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{a.toLocaleString()}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-orange-600 font-medium">{b.toLocaleString()}</td>
+                <td className={`px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold ${diff > 0 ? "text-green-600" : diff < 0 ? "text-red-500" : "text-gray-400"}`}>
+                  {diff > 0 ? `+${diff.toLocaleString()}` : diff.toLocaleString()}
+                </td>
+              </tr>
+            );
+          })}
+          {(() => {
+            const diff = resultB.hp - resultA.hp;
+            return (
+              <tr className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                <td className="px-3 py-1.5 border border-gray-100 font-medium text-red-600 sticky left-0 bg-white z-10">HP</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{resultA.hp.toLocaleString()}</td>
+                <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-orange-600 font-medium">{resultB.hp.toLocaleString()}</td>
+                <td className={`px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold ${diff > 0 ? "text-green-600" : diff < 0 ? "text-red-500" : "text-gray-400"}`}>
+                  {diff > 0 ? `+${diff.toLocaleString()}` : diff.toLocaleString()}
+                </td>
+              </tr>
+            );
+          })()}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Equivalent Level Table ────────────────────────────────────────────────────
+
+function EquivalentLevelTable({
+  resultA,
+  eqLevels,
+  currentLevelB,
+}: {
+  resultA: ReturnType<typeof calcPetStats>;
+  eqLevels: Record<StatKey, number | null>;
+  currentLevelB: number;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-500">
+        設定 A の各ステータスに、設定 B が追いつく最低レベル
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-gray-50 text-xs text-gray-500">
+              <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">A の値</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">B の追いつきLv</th>
+            </tr>
+          </thead>
+          <tbody>
+            {STAT_DISPLAY.map(({ key, label }) => {
+              const eqLv = eqLevels[key];
+              const targetVal = resultA.final[key];
+              const isAlreadyAchieved = eqLv !== null && eqLv <= currentLevelB;
+              return (
+                <tr key={key} className="group even:bg-gray-50/50 hover:bg-gray-100/50 transition-colors">
+                  <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600 sticky left-0 bg-white group-even:bg-gray-50/50 group-hover:bg-gray-100/50 z-10">{label}</td>
+                  <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{targetVal.toLocaleString()}</td>
+                  <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold">
+                    {eqLv === null ? (
+                      <span className="text-red-400">Lv.1200でも届かない</span>
+                    ) : isAlreadyAchieved ? (
+                      <span className="text-green-600">達成済み (Lv.{eqLv.toLocaleString()})</span>
+                    ) : (
+                      <span className="text-orange-600">Lv.{eqLv.toLocaleString()}</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Single Stat Panel ─────────────────────────────────────────────────────────
+
+function PetStatPanel({ result, label }: { result: ReturnType<typeof calcPetStats>; label: string }) {
+  const { t: tGame } = useTranslation("game");
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <p className="text-xs font-semibold text-gray-500">{label}</p>
+        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600">
+          {tGame(`element.${result.element}`)} / {tGame(`attackType.${result.attackMode}`)}
+        </span>
+      </div>
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="bg-gray-50 text-xs text-gray-500">
+            <th className="text-left px-3 py-2 border border-gray-100">ステータス</th>
+            <th className="text-right px-3 py-2 border border-gray-100">値</th>
+          </tr>
+        </thead>
+        <tbody>
+          {STAT_DISPLAY.map(({ key, label: statLabel }) => (
+            <tr key={key} className="even:bg-gray-50/50">
+              <td className="px-3 py-1.5 border border-gray-100 font-medium text-gray-600">{statLabel}</td>
+              <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold text-blue-700">{result.final[key].toLocaleString()}</td>
+            </tr>
+          ))}
+          <tr className="bg-red-50/60">
+            <td className="px-3 py-1.5 border border-gray-100 font-medium text-red-600">HP</td>
+            <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold text-red-600">{result.hp.toLocaleString()}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export function PetSimulator() {
+  type PetCfgTuple = [PetDamageConfig, <K extends keyof PetDamageConfig>(field: K, value: PetDamageConfig[K]) => void, () => void, (s: PetDamageConfig) => void];
+  const [cfgA, setFieldA, resetA, replaceAllA] = usePersistedGroup<PetDamageConfig & Record<string, unknown>>(
+    "pet-sim:a",
+    DEFAULT_PET_DAMAGE_CONFIG as PetDamageConfig & Record<string, unknown>,
+  ) as unknown as PetCfgTuple;
+  const [cfgB, setFieldB, resetB, replaceAllB] = usePersistedGroup<PetDamageConfig & Record<string, unknown>>(
+    "pet-sim:b",
+    DEFAULT_PET_DAMAGE_CONFIG as PetDamageConfig & Record<string, unknown>,
+  ) as unknown as PetCfgTuple;
+  const [activeConfig, setActiveConfig] = usePersistedState<"A" | "B">("pet-sim:active", "A");
+
+  const allMonsters = useAllMonsters();
+
+  const monsterA = useMemo(
+    () => (cfgA.petMonsterName ? allMonsters.find((m) => m.name === cfgA.petMonsterName) ?? null : null),
+    [cfgA.petMonsterName, allMonsters],
+  );
+  const monsterB = useMemo(
+    () => (cfgB.petMonsterName ? allMonsters.find((m) => m.name === cfgB.petMonsterName) ?? null : null),
+    [cfgB.petMonsterName, allMonsters],
+  );
+
+  const resultA = useMemo(() => (monsterA ? calcPetStats(cfgA, monsterA) : null), [cfgA, monsterA]);
+  const resultB = useMemo(() => (monsterB ? calcPetStats(cfgB, monsterB) : null), [cfgB, monsterB]);
+
+  const eqLevels = useMemo(() => {
+    if (!resultA || !monsterB) return null;
+    return findEquivalentLevels(resultA, cfgB, monsterB);
+  }, [resultA, cfgB, monsterB]);
+
+  const activeCfg = activeConfig === "A" ? cfgA : cfgB;
+  const activeSetField = activeConfig === "A" ? setFieldA : setFieldB;
+  const activeReset = activeConfig === "A" ? resetA : resetB;
+  const activeReplaceAll = activeConfig === "A" ? replaceAllA : replaceAllB;
+  const activeResult = activeConfig === "A" ? resultA : resultB;
+
+  const showCompare = resultA !== null && resultB !== null;
+  const showEqLevels = resultA !== null && resultB !== null && eqLevels !== null;
+
+  return (
+    <div className="lg:grid lg:grid-cols-[minmax(340px,400px)_1fr] lg:gap-6">
+      {/* 左パネル（入力） */}
+      <div className="space-y-4">
+        {/* A/B 設定タブ */}
+        <div className="flex rounded-xl overflow-hidden border border-gray-200">
+          {(["A", "B"] as const).map((id) => (
+            <button
+              key={id}
+              onClick={() => setActiveConfig(id)}
+              className={`flex-1 py-2 text-sm font-semibold transition-colors ${
+                activeConfig === id
+                  ? id === "A"
+                    ? "bg-blue-500 text-white"
+                    : "bg-orange-400 text-white"
+                  : "bg-white text-gray-500 hover:bg-gray-50"
+              }`}
+            >
+              設定 {id}
+            </button>
+          ))}
+        </div>
+
+        <PetConfigPanel
+          config={activeCfg}
+          setField={activeSetField}
+          reset={activeReset}
+          petResult={activeResult}
+          replaceConfig={activeReplaceAll}
+        />
+      </div>
+
+      {/* 右パネル（結果） */}
+      <div className="mt-6 lg:mt-0 space-y-4">
+        {showCompare ? (
+          <>
+            {/* 比較テーブル */}
+            <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+              <h2 className="text-base font-bold text-gray-700">ステータス比較</h2>
+              <PetCompareTable resultA={resultA} resultB={resultB} />
+            </div>
+
+            {/* 追いつきレベル */}
+            {showEqLevels && (
+              <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+                <h2 className="text-base font-bold text-gray-700">追いつきレベル（A→B）</h2>
+                <EquivalentLevelTable
+                  resultA={resultA}
+                  eqLevels={eqLevels}
+                  currentLevelB={cfgB.petLevel}
+                />
+              </div>
+            )}
+
+            {/* 個別詳細（比較中も表示） */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="bg-blue-50 rounded-xl border border-blue-100 p-4">
+                <PetStatPanel result={resultA} label="設定 A の詳細" />
+              </div>
+              <div className="bg-orange-50 rounded-xl border border-orange-100 p-4">
+                <PetStatPanel result={resultB} label="設定 B の詳細" />
+              </div>
+            </div>
+          </>
+        ) : activeResult ? (
+          /* 片方のみ設定済み */
+          <div className="bg-white rounded-xl border border-gray-200 p-4">
+            <PetStatPanel
+              result={activeResult}
+              label={`設定 ${activeConfig} のステータス`}
+            />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
+            ペットを選択してください
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/TabNav.tsx
+++ b/src/components/ui/TabNav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 export interface Tab {
@@ -7,6 +7,7 @@ export interface Tab {
   shortLabel?: string;
   icon?: string;
   disabled?: boolean;
+  overflow?: boolean;  // true のタブは「⋯」ドロップダウンに格納
 }
 
 export function TabNav({
@@ -22,6 +23,8 @@ export function TabNav({
     const found = tabs.find((t) => t.id === hash && !t.disabled);
     return found ? found.id : tabs[0].id;
   });
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -36,16 +39,32 @@ export function TabNav({
     return () => window.removeEventListener("hashchange", handleHashChange);
   }, [tabs, onTabChange]);
 
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [dropdownOpen]);
+
   const handleClick = (tab: Tab) => {
     if (tab.disabled) return;
     setActiveTab(tab.id);
     window.location.hash = tab.id;
     onTabChange(tab.id);
+    setDropdownOpen(false);
   };
+
+  const mainTabs = tabs.filter((t) => !t.overflow);
+  const overflowTabs = tabs.filter((t) => t.overflow);
+  const isOverflowActive = overflowTabs.some((t) => t.id === activeTab);
 
   return (
     <div className="flex gap-1 bg-gray-100 rounded-xl p-1">
-      {tabs.map((tab) => (
+      {mainTabs.map((tab) => (
         <button
           key={tab.id}
           onClick={() => handleClick(tab)}
@@ -66,6 +85,59 @@ export function TabNav({
           )}
         </button>
       ))}
+
+      {overflowTabs.length > 0 && (
+        <div ref={dropdownRef} className="relative">
+          <button
+            onClick={(e) => { e.stopPropagation(); setDropdownOpen((v) => !v); }}
+            className={`px-2 sm:px-3 py-2 rounded-lg text-xs sm:text-sm font-medium transition-all ${
+              isOverflowActive
+                ? "bg-white text-gray-800 shadow-sm"
+                : dropdownOpen
+                  ? "bg-white/70 text-gray-700"
+                  : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {isOverflowActive
+              ? (() => {
+                  const active = overflowTabs.find((t) => t.id === activeTab)!;
+                  return (
+                    <>
+                      {active.icon && <span className="mr-1">{active.icon}</span>}
+                      <span className="sm:hidden">{active.shortLabel ?? active.label}</span>
+                      <span className="hidden sm:inline">{active.label}</span>
+                    </>
+                  );
+                })()
+              : "⋯"}
+          </button>
+
+          {dropdownOpen && (
+            <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg z-30 py-1 min-w-[140px]">
+              {overflowTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => handleClick(tab)}
+                  disabled={tab.disabled}
+                  className={`w-full text-left px-4 py-2.5 text-sm transition-colors ${
+                    activeTab === tab.id
+                      ? "text-gray-800 font-semibold bg-gray-50"
+                      : tab.disabled
+                        ? "text-gray-300 cursor-not-allowed"
+                        : "text-gray-600 hover:bg-gray-50"
+                  }`}
+                >
+                  {tab.icon && <span className="mr-1.5">{tab.icon}</span>}
+                  {tab.label}
+                  {tab.disabled && (
+                    <span className="ml-1 text-xs text-gray-300">{t("preparing")}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -11,7 +11,9 @@
     "farm": "Farming",
     "farmShort": "Farm",
     "monsters": "Monster Editor",
-    "monstersShort": "MON"
+    "monstersShort": "MON",
+    "pet": "Pet Sim",
+    "petShort": "Pet"
   },
   "preparing": "Coming Soon",
   "add": "Add",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -11,7 +11,9 @@
     "farm": "周回計算",
     "farmShort": "周回計",
     "monsters": "モンスター登録",
-    "monstersShort": "図鑑"
+    "monstersShort": "図鑑",
+    "pet": "ペットシミュ",
+    "petShort": "ペット"
   },
   "preparing": "準備中",
   "add": "追加",

--- a/src/utils/petStatCalc.ts
+++ b/src/utils/petStatCalc.ts
@@ -78,6 +78,39 @@ function findHighestStatKey(
   return bestKey;
 }
 
+/**
+ * For each stat, find the minimum level for petB config to reach or exceed resultA's stat value.
+ * Returns null for a stat if even level 1200 cannot reach the target.
+ */
+export function findEquivalentLevels(
+  resultA: PetStatResult,
+  cfgB: PetDamageConfig,
+  monsterB: MonsterBase,
+): Record<StatKey, number | null> {
+  const result = {} as Record<StatKey, number | null>;
+  const maxResult = calcPetStats({ ...cfgB, petLevel: 1200 }, monsterB);
+
+  for (const key of STAT_KEYS) {
+    const targetStat = resultA.final[key];
+    if (maxResult.final[key] < targetStat) {
+      result[key] = null;
+      continue;
+    }
+    let lo = 1, hi = 1200;
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const midResult = calcPetStats({ ...cfgB, petLevel: mid }, monsterB);
+      if (midResult.final[key] >= targetStat) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    result[key] = lo;
+  }
+  return result;
+}
+
 export function calcPetStats(config: PetDamageConfig, monsterBase: MonsterBase): PetStatResult {
   const maxLevel = 1200;
   const level = Math.min(config.petLevel, maxLevel);


### PR DESCRIPTION
## 変更内容

タブが6個になってヘッダーが混雑してきたため、「周回計算」と「モンスター登録」を `⋯` ドロップダウンに格納してメインタブを5個以内に絞った。

### 実装
- `Tab` 型に `overflow?: boolean` を追加
- `TabNav` がoverflowタブを末尾の `⋯` ボタンのドロップダウンに格納
- overflow中のタブが選択されているときは `⋯` の代わりにそのタブ名を表示
- クリック外で閉じる（既存の mobile menu と同じパターン）
- `App.tsx` で farm・monsters に `overflow: true` を付与

### タブ構成（変更後）
| メイン表示 | ⋯ ドロップダウン |
|-----------|----------------|
| ⚔ ダメージ計算 | ♻ 周回計算 |
| 🏟 裏路地 | 📋 モンスター登録 |
| ✦ ステータス | |
| 🐾 ペットシミュ | |

## 確認事項
- [x] ビルド成功
- [x] overflow中タブが選択中の場合、ボタンにタブ名を表示
- [x] 破壊的変更なし（Tab型の overflow は optional）

🤖 Generated with [Claude Code](https://claude.com/claude-code)