### PR TITLE
fix: 多段魔法のオーバーキル判定を1発基準に修正

### DIFF
--- a/src/components/DamageCalculator.tsx
+++ b/src/components/DamageCalculator.tsx
@@ -416,8 +416,9 @@ export function DamageCalculator() {
           )
         );
         const overkillThreshold = scaled.hp * 10;
-        const overkillGuaranteed = !dmg.isNullified && totalMin >= overkillThreshold;
-        const overkillPossible = !dmg.isNullified && totalMax >= overkillThreshold;
+        // オーバーキルは1発でHP×10以上が必要。多段魔法（火魔法等）でも合計ではなく1発で判定
+        const overkillGuaranteed = !dmg.isNullified && dmg.min >= overkillThreshold;
+        const overkillPossible = !dmg.isNullified && dmg.max >= overkillThreshold;
         const overkillStatNeeded = calcIntForKill(
           scaled.hp * 10,
           scaled.scaledDef,
@@ -425,7 +426,7 @@ export function DamageCalculator() {
           selfToEnemyAffinity,
           effectiveMult,
           activeMagicBaseInt,
-          spell.hits,
+          1,
           activeCrystalCubeFinalMult
         );
         // 現在のINTでOverKillするのに必要な魔晶立方体の最小数（0〜1000）

--- a/src/utils/multiDamageCalc.ts
+++ b/src/utils/multiDamageCalc.ts
@@ -93,7 +93,8 @@ export function calcOffensiveComparison(
         const totalMin = dmg.isNullified ? spell.hits : dmg.min * spell.hits;
         const totalMax = dmg.isNullified ? 9 * spell.hits : dmg.max * spell.hits;
         const hitsToKill = calcHitsToKill(scaled.hp, dmg.isNullified ? 1 : dmg.min, spell.hits);
-        const overkillGuaranteed = !dmg.isNullified && totalMin >= scaled.hp * 10;
+        // オーバーキルは1発でHP×10以上が必要。多段魔法（火魔法等）でも合計ではなく1発で判定
+        const overkillGuaranteed = !dmg.isNullified && dmg.min >= scaled.hp * 10;
         const overkillStatNeeded = calcIntForKill(
           scaled.hp * 10,
           scaled.scaledDef,
@@ -101,7 +102,7 @@ export function calcOffensiveComparison(
           affinity,
           effectiveMult,
           magicParams.magicBaseInt,
-          spell.hits,
+          1,
           magicParams.crystalCubeFinalMult
         );
         return { spell, dmg, totalMin, totalMax, hitsToKill, overkillGuaranteed, overkillStatNeeded };


### PR DESCRIPTION
## 問題
火魔法（0.5秒ごとに1回×4ヒット）のオーバーキル判定が、4発の合計ダメージで判定されていた。

## 原因
`multiDamageCalc.ts` と `DamageCalculator.tsx` の両方で、`totalMin = dmg.min * spell.hits` を使ってオーバーキル閾値（HP×10）と比較していた。

## 修正
- オーバーキル判定: `totalMin >= hp*10` → `dmg.min >= hp*10`（1発基準）
- オーバーキル達成に必要なINT計算: `spell.hits` → `1` を `calcIntForKill` に渡す

## 確認
- `npx tsc --noEmit` 型エラーなし