### PR TITLE
fix: 敵プリセットモーダルのPC表示幅を拡張

### DIFF
--- a/src/components/ui/EnemyPresetModal.tsx
+++ b/src/components/ui/EnemyPresetModal.tsx
@@ -70,7 +70,7 @@ export function EnemyPresetModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
       <div className="absolute inset-0 bg-black/50" onClick={handleClose} />
-      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-3xl flex flex-col" style={{ height: "min(640px, 85vh)" }}>
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-4xl flex flex-col" style={{ height: "min(640px, 85vh)" }}>
 
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 flex-shrink-0">


### PR DESCRIPTION
## Summary
- 魔法無効ラベル追加によってモンスター名列が狭くなっていた問題を修正
- PC版の敵プリセットモーダル幅を `max-w-3xl`(768px) → `max-w-4xl`(896px) に変更
- モバイルは `w-full` のため影響なし

## Test plan
- [ ] PC表示でモンスター名が十分な幅で表示されることを確認
- [ ] 魔法無効ラベルがモンスター名と並んで見やすいことを確認
- [ ] モバイル表示に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)