### PR TITLE
fix: 敵プリセットモーダルの出現場所列幅を拡張

### DIFF
--- a/src/components/ui/EnemyPresetModal.tsx
+++ b/src/components/ui/EnemyPresetModal.tsx
@@ -142,7 +142,7 @@ export function EnemyPresetModal({
               {multiSelect && <span className="w-6" />}
               <span className="flex-1 text-xs font-bold text-gray-600 uppercase tracking-wide">{t("game:name")}</span>
               <span className="w-28 text-right text-xs font-bold text-gray-600 uppercase tracking-wide">{t("game:level")}</span>
-              <span className="w-44 text-right text-xs font-bold text-gray-600 uppercase tracking-wide">{t("game:location")}</span>
+              <span className="w-56 text-right text-xs font-bold text-gray-600 uppercase tracking-wide">{t("game:location")}</span>
             </div>
             {group?.presets.map((preset, pi) => {
               const isChecked = multiSelect && comparisonKeys?.has(presetKey(preset));
@@ -182,7 +182,7 @@ export function EnemyPresetModal({
                       )}
                     </span>
                     <span className="w-28 text-right text-sm font-mono font-semibold text-indigo-600">{preset.level.toLocaleString()}</span>
-                    <span className="w-44 text-right text-sm text-gray-700">{preset.location}</span>
+                    <span className="w-56 text-right text-sm text-gray-700">{preset.location}</span>
                   </div>
                   <div className="sm:hidden flex items-center gap-2">
                     {multiSelect && (


### PR DESCRIPTION
## 変更内容
- 出現場所列の幅を `w-44`（176px）→ `w-56`（224px）に変更（全角3文字分拡張）
- ヘッダーと行データの両方を更新

## 問題
敵プリセット選択モーダルで出現場所のテキストが改行されていた。

## 確認事項
- [ ] 出現場所テキストが1行に収まること
- [ ] モバイル表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)