### PR TITLE
fix: 裏路地シミュの「ダメ計と同期」が最新値を反映しないバグを修正

### DIFF
--- a/src/components/ArenaCalculator.tsx
+++ b/src/components/ArenaCalculator.tsx
@@ -266,6 +266,13 @@ export function ArenaCalculator() {
   const [mySpd, setMySpd] = usePersistedState("arena:spd", "");
   const [syncWithDmg, setSyncWithDmg] = usePersistedState("arena:sync", false);
   const [syncMode, setSyncMode] = usePersistedState<"manual" | "sim">("arena:syncMode", "manual");
+  // ダメ計タブの手動入力値をリアクティブに読み取る（同期ON時に使用）
+  const [dmgDef] = usePersistedState("dmg:def", "");
+  const [dmgMdef] = usePersistedState("dmg:mdef", "");
+  const [dmgVit] = usePersistedState("dmg:vit", "");
+  const [dmgLuck] = usePersistedState("dmg:luck", "");
+  const [dmgAtk] = usePersistedState("dmg:atk", "");
+  const [dmgSpd] = usePersistedState("dmg:spd", "");
   const [simCfg] = useSharedSimConfig();
   const simResult = useMemo(() => calcStatus(simCfg), [simCfg]);
   const [arenaLevel, setArenaLevel] = usePersistedState(
@@ -279,32 +286,32 @@ export function ArenaCalculator() {
   const effectiveDef = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.def
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:def") ?? '""') || "0") || 0
+      : parseInt(dmgDef) || 0
     : parseInt(myDef) || 0;
   const effectiveMdef = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.mdef
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:mdef") ?? '""') || "0") || 0
+      : parseInt(dmgMdef) || 0
     : parseInt(myMdef) || 0;
   const effectiveVit = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.vit
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:vit") ?? '""') || "0") || 0
+      : parseInt(dmgVit) || 0
     : parseInt(myVit) || 0;
   const effectiveLuk = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.luck
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:luck") ?? '""') || "0") || 0
+      : parseInt(dmgLuck) || 0
     : parseInt(myLuk) || 0;
   const effectiveAtk = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.atk
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:atk") ?? '""') || "0") || 0
+      : parseInt(dmgAtk) || 0
     : parseInt(myAtk) || 0;
   const effectiveSpd = syncWithDmg
     ? syncMode === "sim"
       ? simResult.final.spd
-      : parseInt(JSON.parse(localStorage.getItem("owt:dmg:spd") ?? '""') || "0") || 0
+      : parseInt(dmgSpd) || 0
     : parseInt(mySpd) || 0;
 
   const playerHp = effectiveVit > 0 ? effectiveVit * 18 + 100 : 0;

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -2,13 +2,18 @@ import { useState, useEffect, useCallback } from "react";
 
 const STORAGE_PREFIX = "owt:";
 
+/**
+ * Persisted state hook with cross-component synchronization.
+ * Multiple instances using the same key stay in sync via CustomEvent.
+ */
 export function usePersistedState<T>(
   key: string,
   defaultValue: T
 ): [T, (value: T | ((prev: T) => T)) => void] {
   const storageKey = STORAGE_PREFIX + key;
+  const eventName = `owt:ps:${key}`;
 
-  const [value, setValue] = useState<T>(() => {
+  const [value, setValueRaw] = useState<T>(() => {
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored !== null) return JSON.parse(stored);
@@ -18,13 +23,39 @@ export function usePersistedState<T>(
     return defaultValue;
   });
 
+  // Listen for changes from other component instances using the same key
   useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(value));
-    } catch {
-      // ignore quota errors
-    }
-  }, [storageKey, value]);
+    const handler = () => {
+      try {
+        const raw = localStorage.getItem(storageKey);
+        if (raw !== null) setValueRaw(JSON.parse(raw));
+      } catch {
+        // ignore
+      }
+    };
+    window.addEventListener(eventName, handler);
+    return () => window.removeEventListener(eventName, handler);
+  }, [storageKey, eventName]);
+
+  // Wrapped setter: persist to localStorage and notify other instances
+  const setValue = useCallback(
+    (update: T | ((prev: T) => T)) => {
+      setValueRaw((prev) => {
+        const next =
+          typeof update === "function"
+            ? (update as (prev: T) => T)(prev)
+            : update;
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(next));
+          window.dispatchEvent(new CustomEvent(eventName));
+        } catch {
+          // ignore quota errors
+        }
+        return next;
+      });
+    },
+    [storageKey, eventName]
+  );
 
   return [value, setValue];
 }


### PR DESCRIPTION
## Summary
- 裏路地シミュレーターで「ダメ計と同期」ON + 手動入力モード時、ダメ計タブの値変更がリアルタイムに反映されないバグを修正
- `usePersistedState` にCustomEventベースのクロスコンポーネント同期を追加（`useSharedSimConfig` と同じパターン）
- `ArenaCalculator` の生 `localStorage.getItem()` 呼び出しをリアクティブな `usePersistedState` hookに置換

## 原因
`ArenaCalculator` が `localStorage.getItem("owt:dmg:def")` 等を直接呼んでおり、レンダー時の一回限りの読み取りだった。DamageCalculator側で値が変わっても再レンダーがトリガーされないため、古い値が残り続けていた。

## Test plan
- [ ] ダメ計タブで手動入力値を変更 → 裏路地タブ（同期ON・手動入力モード）に切り替え → 最新値が反映されていること
- [ ] ダメ計タブで値を変更しながら裏路地タブを表示 → リアルタイムに更新されること
- [ ] 同期OFF時の手動入力が従来通り動作すること
- [ ] 同期ON・装備設定モード（sim）が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)