### PR TITLE
feat(data): 七理の宝環アクセを追加

### DIFF
--- a/docs/data/accessories.json
+++ b/docs/data/accessories.json
@@ -33,5 +33,6 @@
   { "name": "アークゲート",     "maxLevel": 10,   "effects": [{ "type": "経験値",    "value": 500, "scalePercent": 1 }, { "type": "ドロップ率", "value": 500, "scalePercent": 1 }] },
   { "name": "ドミナススローン", "maxLevel": 10,   "effects": [{ "type": "経験値",    "value": 500, "scalePercent": 1 }, { "type": "捕獲率",    "value": 500, "scalePercent": 1 }] },
   { "name": "フォーチュンポット","maxLevel": 10,   "effects": [{ "type": "ドロップ率","value": 1000, "scalePercent": 1 }] },
-  { "name": "ヴォルテクスコア", "maxLevel": 1,    "effects": [{ "type": "MOV",   "value": 3,   "scalePercent": 0  }] }
+  { "name": "ヴォルテクスコア", "maxLevel": 1,    "effects": [{ "type": "MOV",   "value": 3,   "scalePercent": 0  }] },
+  { "name": "七理の宝環",       "maxLevel": 1000, "effects": [{ "type": "VIT%",   "value": 50, "scalePercent": 1 }, { "type": "SPD%", "value": 50, "scalePercent": 1 }, { "type": "ATK%", "value": 50, "scalePercent": 1 }, { "type": "INT%", "value": 50, "scalePercent": 1 }, { "type": "DEF%", "value": 50, "scalePercent": 1 }, { "type": "M-DEF%", "value": 50, "scalePercent": 1 }, { "type": "LUCK%", "value": 50, "scalePercent": 1 }] }
 ]


### PR DESCRIPTION
## 変更内容

- `docs/data/accessories.json` に七理の宝環を末尾追加

## アイテム仕様

| 項目 | 値 |
|------|-----|
| 名前 | 七理の宝環 |
| 最大レベル | 1000 |
| 効果 | VIT%/SPD%/ATK%/INT%/DEF%/M-DEF%/LUCK% 各+50% |

## 確認事項

- [x] 末尾追加（既存URLへの影響なし）
- [x] scalePercent: 1（他の%系アクセと統一）