### PR TITLE
feat(petbattle): 幸運によるHIT率を勝敗予測に反映（検証中）

### DIFF
--- a/src/components/petbattle/BattleDurabilityCard.tsx
+++ b/src/components/petbattle/BattleDurabilityCard.tsx
@@ -41,7 +41,12 @@ export function BattleDurabilityCard({ result, spdA, spdB }: BattleDurabilityCar
       {/* 勝敗予測バッジ */}
       <div className={`rounded-lg border px-3 py-2 ${predictionBadge}`}>
         <div className="flex items-baseline justify-between gap-2">
-          <span className="text-[11px] font-medium opacity-80">{t("prediction.label")}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] font-medium opacity-80">{t("prediction.label")}</span>
+            <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-100 text-yellow-700 border border-yellow-200 font-medium leading-none">
+              {t("prediction.experimental")}
+            </span>
+          </div>
           <span className="text-base font-bold">
             {predictionLabel}
             {Number.isFinite(prediction.turnsToWin) && (

--- a/src/i18n/locales/en/petbattle.json
+++ b/src/i18n/locales/en/petbattle.json
@@ -46,6 +46,7 @@
   },
   "prediction": {
     "label": "Prediction",
+    "experimental": "Luck-based (experimental)",
     "winA": "A wins",
     "winB": "B wins",
     "draw": "Draw",

--- a/src/i18n/locales/ja/petbattle.json
+++ b/src/i18n/locales/ja/petbattle.json
@@ -46,6 +46,7 @@
   },
   "prediction": {
     "label": "勝敗予測",
+    "experimental": "幸運込み・検証中",
     "winA": "A 勝利",
     "winB": "B 勝利",
     "draw": "引き分け",

--- a/src/utils/petBattleCalc.ts
+++ b/src/utils/petBattleCalc.ts
@@ -113,8 +113,9 @@ export function predictWinner(
   bToA: AttackOutcome,
   initiative: InitiativeWinner,
 ): BattlePrediction {
-  const aKillsIn = aToB.hitsToKill.worst;
-  const bKillsIn = bToA.hitsToKill.worst;
+  // ミス率を加味した期待ターン数で勝敗判定
+  const aKillsIn = aToB.expectedTurnsWithMiss;
+  const bKillsIn = bToA.expectedTurnsWithMiss;
 
   if (!Number.isFinite(aKillsIn) && !Number.isFinite(bKillsIn)) {
     return { winner: "draw", turnsToWin: Infinity, note: "stalemate" };


### PR DESCRIPTION
## 変更内容

- **勝敗判定ロジック変更** (`petBattleCalc.ts`): `hitsToKill.worst`（ミス無視）→ `expectedTurnsWithMiss`（HIT率込み期待ターン数）を使用して勝敗を決定
- **検証中バッジ追加** (`BattleDurabilityCard.tsx`): 勝敗予測ラベル横に「幸運込み・検証中」バッジを表示（HIT率計算式が未確定のため）
- **i18n** (ja/en): `prediction.experimental` キー追加

## 動作

| 条件 | 変更前 | 変更後 |
|------|--------|--------|
| HIT率 100% | 変わらず | 変わらず |
| HIT率 < 100% | 幸運を無視して判定 | ミス期待分だけターン増・不利に判定 |
| HIT率 0% | 同上 | Infinity → 相手が勝利 |

## 確認事項
- [x] `npx tsc --noEmit` 通過
- [x] `npm test` 全 20 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)