### PR TITLE
feat(magic): 心眼威圧を追加・時流停滞の魔法倍率を修正

### DIFF
--- a/src/data/magicSpells.ts
+++ b/src/data/magicSpells.ts
@@ -14,5 +14,6 @@ export const MAGIC_SPELLS: MagicSpell[] = [
   { name: "大地葬送", element: "木", multiplier: 1.3, hits: 1, spCost: 9 },
   { name: "雷鳴一閃", element: "光", multiplier: 2.0, hits: 1, spCost: 7 },
   { name: "冥刃降臨", element: "闇", multiplier: 1.4, hits: 1, spCost: 11 },
-  { name: "時流停滞", element: "光", multiplier: 1.015, hits: 1, spCost: 7 },
+  { name: "時流停滞", element: "光", multiplier: 1.0,   hits: 1, spCost: 7 },
+  { name: "心眼威圧", element: "火", multiplier: 0.1,   hits: 1, spCost: 25 },
 ];


### PR DESCRIPTION
## 変更内容

- **心眼威圧**（新規追加）: 火・消費SP25・魔法倍率0.1倍
- **時流停滞**（修正）: 魔法倍率 1.015 → 1.0

## 確認事項

- [x] 型チェック通過（`npx tsc --noEmit`）
- [x] `MAGIC_SPELLS` 末尾に追加（既存インデックス変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)