### PR TITLE
fix(ci): GH_TOKENをGITHUB_TOKENに変更してfeedback sync認証エラーを修正

### DIFF
--- a/.github/workflows/feedback-sync.yml
+++ b/.github/workflows/feedback-sync.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
           SHEETS_FEEDBACK_ID: ${{ secrets.SHEETS_FEEDBACK_ID }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO_OWNER: ${{ github.repository_owner }}
           GH_REPO_NAME: ${{ github.event.repository.name }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
期限切れのPATに依存しないよう、ActionsビルトインのGITHUB_TOKENを使用する。
issues: writeパーミッションは既に設定済みなので権限は問題なし。