### PR TITLE
fix(ci): PATCH_NOTES_PATをGITHUB_TOKENに変更してcheckout認証エラーを修正

### DIFF
--- a/.github/workflows/update-patchnotes.yml
+++ b/.github/workflows/update-patchnotes.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # git log を全件取得するため
-          token: ${{ secrets.PATCH_NOTES_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
期限切れPATによるgit fetch失敗を解消。
contents: writeは既設定、paths-ignoreでループ防止も済み。