### PR TITLE
revert(ci): PATCH_NOTES_PATに戻す

### DIFF
--- a/.github/workflows/update-patchnotes.yml
+++ b/.github/workflows/update-patchnotes.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # git log を全件取得するため
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PATCH_NOTES_PAT }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
GITHUB_TOKENはブランチ保護ルールをバイパスできないため、
mainへの直接pushが必要なこのワークフローには使えない。
PATを再発行してシークレットに設定し直すことで対応する。