### PR TITLE
fix(petbattle): LUK命中率をヒル関数に更新・検証中バッジ削除

### DIFF
--- a/src/__tests__/utils/damageCalc.test.ts
+++ b/src/__tests__/utils/damageCalc.test.ts
@@ -400,38 +400,25 @@ describe("calcHitRate", () => {
     expect(calcHitRate(50, -10)).toBe(100);
   });
 
-  it("ratio < 0.5 → 1%", () => {
-    // playerLuck=10, enemyLuck=100 → ratio=0.1 < 0.5
-    expect(calcHitRate(10, 100)).toBe(1);
+  it("very low ratio → 1% (min clamp)", () => {
     expect(calcHitRate(0, 100)).toBe(1);
-    expect(calcHitRate(49, 100)).toBe(1);
+    expect(calcHitRate(10, 100)).toBe(1);
   });
 
-  it("ratio = 0.5 → boundary (should be > 1)", () => {
-    // ratio=0.5 → 1 + ((0.5-0.5)/0.5)*99 = 1
-    expect(calcHitRate(50, 100)).toBe(1);
+  it("ratio = 0.5 → ~43% (Hill function, K=0.529)", () => {
+    expect(calcHitRate(50, 100)).toBe(43);
   });
 
-  it("ratio >= 1.0 → 100%", () => {
-    expect(calcHitRate(100, 100)).toBe(100);
+  it("ratio = K (0.529) → 50% (inflection point)", () => {
+    expect(calcHitRate(529, 1000)).toBe(50);
+  });
+
+  it("ratio = 1.0 → ~96%", () => {
+    expect(calcHitRate(100, 100)).toBe(96);
+  });
+
+  it("ratio >= 2.0 → 100% (max clamp)", () => {
     expect(calcHitRate(200, 100)).toBe(100);
-  });
-
-  it("linear interpolation between 0.5 and 1.0", () => {
-    // ratio=0.75 → 1 + ((0.75-0.5)/0.5)*99 = 1 + 0.5*99 = 1 + 49.5 = 50.5 → round → 51
-    expect(calcHitRate(75, 100)).toBe(Math.round(1 + ((0.75 - 0.5) / 0.5) * 99));
-  });
-
-  it("ratio just above 0.5", () => {
-    // playerLuck=51, enemyLuck=100 → ratio=0.51
-    // 1 + ((0.51-0.5)/0.5)*99 = 1 + (0.01/0.5)*99 = 1 + 1.98 = 2.98 → round → 3
-    expect(calcHitRate(51, 100)).toBe(Math.round(1 + ((0.51 - 0.5) / 0.5) * 99));
-  });
-
-  it("ratio just below 1.0", () => {
-    // playerLuck=99, enemyLuck=100 → ratio=0.99
-    // 1 + ((0.99-0.5)/0.5)*99 = 1 + 0.98*99 = 1 + 97.02 = 98.02 → round → 98
-    expect(calcHitRate(99, 100)).toBe(Math.round(1 + ((0.99 - 0.5) / 0.5) * 99));
   });
 });
 

--- a/src/components/petbattle/BattleDurabilityCard.tsx
+++ b/src/components/petbattle/BattleDurabilityCard.tsx
@@ -43,9 +43,6 @@ export function BattleDurabilityCard({ result, spdA, spdB }: BattleDurabilityCar
         <div className="flex items-baseline justify-between gap-2">
           <div className="flex items-center gap-1.5">
             <span className="text-[11px] font-medium opacity-80">{t("prediction.label")}</span>
-            <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-100 text-yellow-700 border border-yellow-200 font-medium leading-none">
-              {t("prediction.experimental")}
-            </span>
           </div>
           <span className="text-base font-bold">
             {predictionLabel}

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -15,6 +15,7 @@ export const patchNotes: PatchEntry[] = [
   {
     date: "2026-04-17",
     changes: [
+    { type: "fix", text: "ペットバトル：幸運によるHIT率計算式をヒル関数に更新（実測データでフィット・検証中バッジを削除）" },
     { type: "improve", text: "revert(ci): PATCH_NOTES_PATに戻す" },
     { type: "fix", text: "fix(ci): PATCH_NOTES_PATをGITHUB_TOKENに変更してcheckout認証エラーを修正" },
     { type: "fix", text: "fix(ci): GH_TOKENをGITHUB_TOKENに変更してfeedback sync認証エラーを修正" },

--- a/src/i18n/locales/en/petbattle.json
+++ b/src/i18n/locales/en/petbattle.json
@@ -46,7 +46,6 @@
   },
   "prediction": {
     "label": "Prediction",
-    "experimental": "Luck-based (experimental)",
     "winA": "A wins",
     "winB": "B wins",
     "draw": "Draw",

--- a/src/i18n/locales/ja/petbattle.json
+++ b/src/i18n/locales/ja/petbattle.json
@@ -46,7 +46,6 @@
   },
   "prediction": {
     "label": "勝敗予測",
-    "experimental": "幸運込み・検証中",
     "winA": "A 勝利",
     "winB": "B 勝利",
     "draw": "引き分け",

--- a/src/utils/damageCalc.ts
+++ b/src/utils/damageCalc.ts
@@ -207,16 +207,15 @@ export function calcAtkForKill(
 
 /**
  * 命中率を計算（物理攻撃のみ）
- * playerLuck < enemyLuck × 0.5 → 1%
- * playerLuck ≥ enemyLuck → 100%
- * その間: 線形補間
+ * ヒル関数: ratio^5 / (ratio^5 + K^5), K=0.529
+ * 実測フィット: ratio=0.5→~43%, ratio=1.0→~96%
  */
 export function calcHitRate(playerLuck: number, enemyLuck: number): number {
   if (enemyLuck <= 0) return 100;
   const ratio = playerLuck / enemyLuck;
-  if (ratio < 0.5) return 1;
-  if (ratio >= 1.0) return 100;
-  return Math.round(1 + ((ratio - 0.5) / 0.5) * 99);
+  const r5 = Math.pow(ratio, 5);
+  const K5 = Math.pow(0.529, 5);
+  return Math.max(1, Math.min(100, Math.round((r5 / (r5 + K5)) * 100)));
 }
 
 /**


### PR DESCRIPTION
## Summary

- `calcHitRate` を線形補間式からヒル関数 `ratio^5 / (ratio^5 + K^5)`（K=0.529）に変更
- 検証中バッジ（黄色）を `BattleDurabilityCard` から削除
- i18n の `experimental` キーを ja/en 両方から削除
- テストを新式の期待値に更新

## 変更の背景

Issue #120 の実測データ（BOX 雪山【禁域】 Lv50000）でフィット検証済み：

| ratio | 旧式予測 | 新式予測 | 実測 |
|-------|---------|---------|------|
| 0.5 | 1% | 43% | 41.7% |
| 1.0 | 100% | 96% | ~95.7% |
| 0.25 | 1% | 2% | 1.3% |

## Test plan

- [ ] `npm test` で `calcHitRate` テスト全pass確認
- [ ] ペットバトルシミュで「検証中」バッジが非表示になっていること
- [ ] ratio=0.5 付近の命中率表示が約43%になっていること

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)