### PR TITLE
fix(damage): SPD多段HIT計算式を正式仕様に更新・上限撤廃

### DIFF
--- a/src/__tests__/utils/damageCalc.test.ts
+++ b/src/__tests__/utils/damageCalc.test.ts
@@ -205,35 +205,59 @@ describe("calcMultiHitCount", () => {
     expect(calcMultiHitCount(3000, false)).toBe(2);
   });
 
-  it("SPD 3001-9999 → 2 hits", () => {
+  it("SPD 3001-8999 → 2 hits", () => {
     expect(calcMultiHitCount(5000, false)).toBe(2);
-    expect(calcMultiHitCount(9999, false)).toBe(2);
+    expect(calcMultiHitCount(8999, false)).toBe(2);
   });
 
-  it("SPD = 10000 → 3 hits (boundary)", () => {
-    expect(calcMultiHitCount(10000, false)).toBe(3);
+  it("SPD = 9000 → 3 hits (boundary)", () => {
+    expect(calcMultiHitCount(9000, false)).toBe(3);
   });
 
-  it("SPD 10001-29999 → 3 hits", () => {
-    expect(calcMultiHitCount(20000, false)).toBe(3);
-    expect(calcMultiHitCount(29999, false)).toBe(3);
+  it("SPD 9001-26999 → 3 hits", () => {
+    expect(calcMultiHitCount(9001, false)).toBe(3);
+    expect(calcMultiHitCount(26999, false)).toBe(3);
   });
 
-  it("SPD = 30000 → 4 hits (boundary)", () => {
-    expect(calcMultiHitCount(30000, false)).toBe(4);
+  it("SPD = 27000 → 4 hits (boundary)", () => {
+    expect(calcMultiHitCount(27000, false)).toBe(4);
   });
 
-  it("SPD 30001-99999 → 4 hits", () => {
-    expect(calcMultiHitCount(50000, false)).toBe(4);
-    expect(calcMultiHitCount(99999, false)).toBe(4);
+  it("SPD = 81000 → 5 hits (boundary)", () => {
+    expect(calcMultiHitCount(81000, false)).toBe(5);
   });
 
-  it("SPD = 100000 → 5 hits (boundary)", () => {
-    expect(calcMultiHitCount(100000, false)).toBe(5);
+  it("SPD = 243000 → 6 hits (boundary)", () => {
+    expect(calcMultiHitCount(243000, false)).toBe(6);
   });
 
-  it("SPD > 100000 → 5 hits (cap)", () => {
-    expect(calcMultiHitCount(999999, false)).toBe(5);
+  it("SPD = 729000 → 7 hits (boundary)", () => {
+    expect(calcMultiHitCount(729000, false)).toBe(7);
+  });
+
+  it("SPD = 2187000 → 8 hits (boundary)", () => {
+    expect(calcMultiHitCount(2_187_000, false)).toBe(8);
+  });
+
+  it("SPD = 6561000 → 9 hits (boundary)", () => {
+    expect(calcMultiHitCount(6_561_000, false)).toBe(9);
+  });
+
+  it("SPD = 19683000 → 10 hits (boundary)", () => {
+    expect(calcMultiHitCount(19_683_000, false)).toBe(10);
+  });
+
+  it("SPD = 59049000 → 11 hits (boundary)", () => {
+    expect(calcMultiHitCount(59_049_000, false)).toBe(11);
+  });
+
+  it("SPD = 177147000 → 12 hits (boundary)", () => {
+    expect(calcMultiHitCount(177_147_000, false)).toBe(12);
+  });
+
+  it("SPD > 177147000 → continues beyond 12 (no cap)", () => {
+    expect(calcMultiHitCount(531_441_000, false)).toBe(13); // 3000 × 3^11
+    expect(calcMultiHitCount(1_594_323_000, false)).toBe(14); // 3000 × 3^12
   });
 });
 

--- a/src/utils/damageCalc.ts
+++ b/src/utils/damageCalc.ts
@@ -98,9 +98,9 @@ function makeDamageRange(base: number, hasCrit = true): DamageRange {
       min: 1,
       max: 9,
       avg: 5,
-      critMin: 0,
-      critMax: 0,
-      critAvg: 0,
+      critMin: 1,
+      critMax: 9,
+      critAvg: 5,
       isNullified: true,
       hasCrit,
     };
@@ -122,18 +122,21 @@ function makeDamageRange(base: number, hasCrit = true): DamageRange {
 
 /**
  * 多段攻撃回数を計算
- * 主人公魔法(魔攻)は常に1回
+ * threshold(n) = 3000 × 3^(n-2)、上限なし
  */
 export function calcMultiHitCount(
   spd: number,
   isPlayerMagic: boolean
 ): number {
   if (isPlayerMagic) return 1;
-  if (spd >= 100000) return 5;
-  if (spd >= 30000) return 4;
-  if (spd >= 10000) return 3;
-  if (spd >= 3000) return 2;
-  return 1;
+  if (spd < 3000) return 1;
+  let hits = 1;
+  let threshold = 3000;
+  while (spd >= threshold) {
+    hits++;
+    threshold *= 3;
+  }
+  return hits;
 }
 
 /**


### PR DESCRIPTION
## 変更内容

- **多段HIT閾値の修正**：旧実装の誤り（10000/30000/100000）を正式仕様（9000/27000/81000）に修正
- **上限撤廃**：ハードコードの×5上限を廃止し、`threshold(n) = 3000 × 3^(n-2)` のwhileループで無限対応
- **バグ修正**：`isNullified`時の`critMin/Max/Avg`が0になるバグを修正（正しくは1/9/5）

## 計算式

```
hits = 1 + count(threshold <= spd)  where threshold = 3000, 9000, 27000, ...
     = floor(log3(spd / 3000)) + 2  (spd >= 3000)
```

×12（SPD 177,147,000）まで実ゲームデータで確認済み。式的には上限なし。

## 確認事項

- [x] 全境界値テスト通過（×2〜×14）
- [x] `calcPhysicalDamage` nullifiedバグ修正確認
- [x] `npm test` 全73件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)