### PR TITLE
feat(pet-selector): ペット選択時にステータス表示と強さ順ソートを追加

### DIFF
--- a/src/components/PetBattleSimulator.tsx
+++ b/src/components/PetBattleSimulator.tsx
@@ -82,6 +82,7 @@ export function PetBattleSimulator() {
           reset={activeReset}
           petResult={activeResult}
           replaceConfig={activeReplaceAll}
+          showPetStats
         />
       </div>
 

--- a/src/components/PetSimulator.tsx
+++ b/src/components/PetSimulator.tsx
@@ -235,6 +235,7 @@ export function PetSimulator() {
           reset={activeReset}
           petResult={activeResult}
           replaceConfig={activeReplaceAll}
+          showPetStats
         />
       </div>
 

--- a/src/components/damage/PetConfigPanel.tsx
+++ b/src/components/damage/PetConfigPanel.tsx
@@ -13,6 +13,7 @@ export interface PetConfigPanelProps {
   reset: () => void;
   petResult: PetStatResult | null;
   replaceConfig?: (cfg: PetDamageConfig) => void;
+  showPetStats?: boolean;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -130,7 +131,7 @@ function CompactInput({
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
-export function PetConfigPanel({ config, setField, reset, petResult, replaceConfig }: PetConfigPanelProps) {
+export function PetConfigPanel({ config, setField, reset, petResult, replaceConfig, showPetStats }: PetConfigPanelProps) {
   const { t } = useTranslation("damage");
   const { t: tGame } = useTranslation("game");
   const { t: tCommon } = useTranslation("common");
@@ -215,6 +216,7 @@ export function PetConfigPanel({ config, setField, reset, petResult, replaceConf
             setField("petMonsterName", monster.name);
             setIsModalOpen(false);
           }}
+          showPetStats={showPetStats}
         />
       </div>
 

--- a/src/components/ui/MonsterSelectorModal.tsx
+++ b/src/components/ui/MonsterSelectorModal.tsx
@@ -3,32 +3,58 @@ import { useTranslation } from "react-i18next";
 import type { MonsterBase, Element } from "../../types/game";
 import { useAllMonsters } from "../../hooks/useAllMonsters";
 
-function calcStatTotal(m: MonsterBase): number {
-  return m.vit + m.atk + m.int + m.def + m.mdef + m.spd + m.luck;
+type SortKey = "default" | "total" | "atk" | "int" | "vit" | "def" | "mdef" | "spd" | "luck";
+
+const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: "default", label: "デフォ" },
+  { key: "total",   label: "合計" },
+  { key: "atk",     label: "ATK" },
+  { key: "int",     label: "INT" },
+  { key: "vit",     label: "VIT" },
+  { key: "def",     label: "DEF" },
+  { key: "mdef",    label: "M-DEF" },
+  { key: "spd",     label: "SPD" },
+  { key: "luck",    label: "LUK" },
+];
+
+function getSortValue(m: MonsterBase, key: SortKey): number {
+  switch (key) {
+    case "total": return m.vit + m.atk + m.int + m.def + m.mdef + m.spd + m.luck;
+    case "atk":   return m.atk;
+    case "int":   return m.int;
+    case "vit":   return m.vit;
+    case "def":   return m.def;
+    case "mdef":  return m.mdef;
+    case "spd":   return m.spd;
+    case "luck":  return m.luck;
+    default:      return 0;
+  }
 }
 
-function PetStatRow({ monster }: { monster: MonsterBase }) {
-  const statDefs = [
-    { label: "ATK", v: monster.atk },
-    { label: "INT", v: monster.int },
-    { label: "VIT", v: monster.vit },
-    { label: "DEF", v: monster.def },
-    { label: "M-DEF", v: monster.mdef },
-    { label: "SPD", v: monster.spd },
-    { label: "LUK", v: monster.luck },
+function PetStatRow({ monster, sortKey }: { monster: MonsterBase; sortKey: SortKey }) {
+  const statDefs: { label: string; key: SortKey; v: number }[] = [
+    { label: "ATK",   key: "atk",  v: monster.atk },
+    { label: "INT",   key: "int",  v: monster.int },
+    { label: "VIT",   key: "vit",  v: monster.vit },
+    { label: "DEF",   key: "def",  v: monster.def },
+    { label: "M-DEF", key: "mdef", v: monster.mdef },
+    { label: "SPD",   key: "spd",  v: monster.spd },
+    { label: "LUK",   key: "luck", v: monster.luck },
   ];
   const total = statDefs.reduce((s, x) => s + x.v, 0);
   return (
     <div className="flex flex-wrap gap-x-2 gap-y-0 mt-0.5 text-[10px] leading-tight">
-      {statDefs.map(({ label, v }) =>
+      {statDefs.map(({ label, key, v }) =>
         v > 0 ? (
-          <span key={label} className="text-gray-500">
-            <span className="text-gray-400">{label} </span>
-            <span className="text-gray-700">{v}</span>
+          <span key={key} className={sortKey === key ? "font-bold text-indigo-600" : "text-gray-500"}>
+            <span className={sortKey === key ? "text-indigo-400" : "text-gray-400"}>{label} </span>
+            <span>{v}</span>
           </span>
         ) : null
       )}
-      <span className="text-gray-600 font-semibold">合計 {total}</span>
+      <span className={`font-semibold ${sortKey === "total" ? "text-indigo-600" : "text-gray-600"}`}>
+        合計 {total}
+      </span>
     </div>
   );
 }
@@ -64,7 +90,7 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
   const { t } = useTranslation("game");
   const [elementFilter, setElementFilter] = useState<ElementFilter>("all");
   const [query, setQuery] = useState("");
-  const [sortByStrength, setSortByStrength] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>("default");
 
   const allMonsters = useAllMonsters();
 
@@ -77,11 +103,11 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
       const lower = query.toLowerCase();
       list = list.filter((m) => m.name.toLowerCase().includes(lower));
     }
-    if (showPetStats && sortByStrength) {
-      list = [...list].sort((a, b) => calcStatTotal(b) - calcStatTotal(a));
+    if (showPetStats && sortKey !== "default") {
+      list = [...list].sort((a, b) => getSortValue(b, sortKey) - getSortValue(a, sortKey));
     }
     return list;
-  }, [allMonsters, elementFilter, query, showPetStats, sortByStrength]);
+  }, [allMonsters, elementFilter, query, showPetStats, sortKey]);
 
   if (!isOpen) return null;
 
@@ -147,33 +173,40 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
 
           {/* モンスター一覧 */}
           <div className="flex-1 overflow-y-auto flex flex-col">
-            {/* 検索バー */}
-            <div className="px-4 py-3 border-b border-gray-200 bg-white sticky top-0 flex items-center gap-2">
-              <input
-                type="text"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                autoFocus
-                placeholder={t("searchByName")}
-                className="flex-1 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400"
-              />
+            {/* 検索バー + ソートバー (sticky unit) */}
+            <div className="border-b border-gray-200 bg-white sticky top-0">
+              <div className="px-4 py-3">
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  autoFocus
+                  placeholder={t("searchByName")}
+                  className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                />
+              </div>
               {showPetStats && (
-                <button
-                  type="button"
-                  onClick={() => setSortByStrength((v) => !v)}
-                  className={`flex-shrink-0 px-2.5 py-1.5 text-xs rounded-lg border font-medium transition-colors ${
-                    sortByStrength
-                      ? "bg-indigo-600 text-white border-indigo-600"
-                      : "bg-white text-gray-500 border-gray-200 hover:bg-gray-50"
-                  }`}
-                >
-                  強さ順
-                </button>
+                <div className="flex overflow-x-auto gap-1.5 px-4 pb-2 shrink-0">
+                  {SORT_OPTIONS.map(({ key, label }) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setSortKey(key)}
+                      className={`flex-shrink-0 px-2.5 py-1 text-xs rounded-full border font-medium transition-colors ${
+                        sortKey === key
+                          ? "bg-indigo-600 text-white border-indigo-600"
+                          : "bg-white text-gray-500 border-gray-200 hover:bg-gray-50"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
               )}
             </div>
 
             {/* PC: カラムヘッダー */}
-            <div className="hidden sm:flex items-center gap-3 px-5 py-2.5 border-b border-gray-200 bg-gray-50 sticky top-[57px]">
+            <div className="hidden sm:flex items-center gap-3 px-5 py-2.5 border-b border-gray-200 bg-gray-50">
               <span className="flex-1 text-xs font-bold text-gray-600 uppercase tracking-wide">{t("name")}</span>
               <span className="w-14 text-center text-xs font-bold text-gray-600 uppercase tracking-wide">{t("game:element.火", { defaultValue: "" }).length > 0 ? t("monsters:element", { defaultValue: t("game:elementFilter.all", { defaultValue: "" }).length > 0 ? "" : "" }) : ""}</span>
               <span className="w-16 text-right text-xs font-bold text-gray-600 uppercase tracking-wide">{t("monsters:attackType", { ns: "monsters" })}</span>
@@ -208,7 +241,7 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
                           {t(`attackType.${monster.attackType}`)}
                         </span>
                       </div>
-                      {showPetStats && <PetStatRow monster={monster} />}
+                      {showPetStats && <PetStatRow monster={monster} sortKey={sortKey} />}
                     </div>
                     {/* Mobile: 名前＋属性バッジ＋攻撃タイプを1行に */}
                     <div className="sm:hidden">
@@ -223,7 +256,7 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
                           {t(`attackType.${monster.attackType}`)}
                         </span>
                       </div>
-                      {showPetStats && <PetStatRow monster={monster} />}
+                      {showPetStats && <PetStatRow monster={monster} sortKey={sortKey} />}
                     </div>
                   </button>
                 ))

--- a/src/components/ui/MonsterSelectorModal.tsx
+++ b/src/components/ui/MonsterSelectorModal.tsx
@@ -3,6 +3,36 @@ import { useTranslation } from "react-i18next";
 import type { MonsterBase, Element } from "../../types/game";
 import { useAllMonsters } from "../../hooks/useAllMonsters";
 
+function calcStatTotal(m: MonsterBase): number {
+  return m.vit + m.atk + m.int + m.def + m.mdef + m.spd + m.luck;
+}
+
+function PetStatRow({ monster }: { monster: MonsterBase }) {
+  const statDefs = [
+    { label: "ATK", v: monster.atk },
+    { label: "INT", v: monster.int },
+    { label: "VIT", v: monster.vit },
+    { label: "DEF", v: monster.def },
+    { label: "M-DEF", v: monster.mdef },
+    { label: "SPD", v: monster.spd },
+    { label: "LUK", v: monster.luck },
+  ];
+  const total = statDefs.reduce((s, x) => s + x.v, 0);
+  return (
+    <div className="flex flex-wrap gap-x-2 gap-y-0 mt-0.5 text-[10px] leading-tight">
+      {statDefs.map(({ label, v }) =>
+        v > 0 ? (
+          <span key={label} className="text-gray-500">
+            <span className="text-gray-400">{label} </span>
+            <span className="text-gray-700">{v}</span>
+          </span>
+        ) : null
+      )}
+      <span className="text-gray-600 font-semibold">合計 {total}</span>
+    </div>
+  );
+}
+
 type ElementFilter = "all" | Element;
 
 const ELEMENTS: Element[] = ["火", "水", "木", "光", "闇"];
@@ -27,12 +57,14 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onSelect: (monster: MonsterBase) => void;
+  showPetStats?: boolean;
 }
 
-export function MonsterSelectorModal({ isOpen, onClose, onSelect }: Props) {
+export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }: Props) {
   const { t } = useTranslation("game");
   const [elementFilter, setElementFilter] = useState<ElementFilter>("all");
   const [query, setQuery] = useState("");
+  const [sortByStrength, setSortByStrength] = useState(false);
 
   const allMonsters = useAllMonsters();
 
@@ -45,8 +77,11 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect }: Props) {
       const lower = query.toLowerCase();
       list = list.filter((m) => m.name.toLowerCase().includes(lower));
     }
+    if (showPetStats && sortByStrength) {
+      list = [...list].sort((a, b) => calcStatTotal(b) - calcStatTotal(a));
+    }
     return list;
-  }, [allMonsters, elementFilter, query]);
+  }, [allMonsters, elementFilter, query, showPetStats, sortByStrength]);
 
   if (!isOpen) return null;
 
@@ -113,15 +148,28 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect }: Props) {
           {/* モンスター一覧 */}
           <div className="flex-1 overflow-y-auto flex flex-col">
             {/* 検索バー */}
-            <div className="px-4 py-3 border-b border-gray-200 bg-white sticky top-0">
+            <div className="px-4 py-3 border-b border-gray-200 bg-white sticky top-0 flex items-center gap-2">
               <input
                 type="text"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 autoFocus
                 placeholder={t("searchByName")}
-                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                className="flex-1 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400"
               />
+              {showPetStats && (
+                <button
+                  type="button"
+                  onClick={() => setSortByStrength((v) => !v)}
+                  className={`flex-shrink-0 px-2.5 py-1.5 text-xs rounded-lg border font-medium transition-colors ${
+                    sortByStrength
+                      ? "bg-indigo-600 text-white border-indigo-600"
+                      : "bg-white text-gray-500 border-gray-200 hover:bg-gray-50"
+                  }`}
+                >
+                  強さ順
+                </button>
+              )}
             </div>
 
             {/* PC: カラムヘッダー */}
@@ -148,28 +196,34 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect }: Props) {
                     className="w-full px-5 py-3 hover:bg-indigo-50 border-b border-gray-100 text-left transition-colors group"
                   >
                     {/* PC: 横並び */}
-                    <div className="hidden sm:flex items-center gap-3">
-                      <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
-                        {monster.name}
-                      </span>
-                      <span className={`w-14 text-center text-xs px-2 py-0.5 rounded-full font-medium ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
-                        {t(`element.${monster.element}`)}
-                      </span>
-                      <span className="w-16 text-right text-sm text-gray-700">
-                        {t(`attackType.${monster.attackType}`)}
-                      </span>
+                    <div className="hidden sm:block">
+                      <div className="flex items-center gap-3">
+                        <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
+                          {monster.name}
+                        </span>
+                        <span className={`w-14 text-center text-xs px-2 py-0.5 rounded-full font-medium ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
+                          {t(`element.${monster.element}`)}
+                        </span>
+                        <span className="w-16 text-right text-sm text-gray-700">
+                          {t(`attackType.${monster.attackType}`)}
+                        </span>
+                      </div>
+                      {showPetStats && <PetStatRow monster={monster} />}
                     </div>
                     {/* Mobile: 名前＋属性バッジ＋攻撃タイプを1行に */}
-                    <div className="sm:hidden flex items-center gap-2">
-                      <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
-                        {monster.name}
-                      </span>
-                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
-                        {t(`element.${monster.element}`)}
-                      </span>
-                      <span className="text-xs text-gray-500 flex-shrink-0">
-                        {t(`attackType.${monster.attackType}`)}
-                      </span>
+                    <div className="sm:hidden">
+                      <div className="flex items-center gap-2">
+                        <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
+                          {monster.name}
+                        </span>
+                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
+                          {t(`element.${monster.element}`)}
+                        </span>
+                        <span className="text-xs text-gray-500 flex-shrink-0">
+                          {t(`attackType.${monster.attackType}`)}
+                        </span>
+                      </div>
+                      {showPetStats && <PetStatRow monster={monster} />}
                     </div>
                   </button>
                 ))


### PR DESCRIPTION
## 変更内容

- ペットシミュ・バトルシミュのペット選択モーダルで各ペットのステータスを表示
  - ATK / INT / VIT / DEF / M-DEF / SPD / LUK（0のステータスは非表示）
  - 合計値（7ステータスの合算）を各行に表示
- 「強さ順」ボタンで合計値降順ソートに切り替え可能
- ダメージシミュの敵選択（`MonsterSelectorModal`）には影響なし

## 実装方針

- `MonsterSelectorModal` に `showPetStats?: boolean` prop を追加
- `PetConfigPanel` 経由で `showPetStats` を転送
- `PetBattleSimulator` / `PetSimulator` のみ `showPetStats={true}` を渡す
- `DamageCalculator` はprop未指定のため変更なし

## 確認事項

- [ ] ペットバトルシミュのペット選択でステータスが表示される
- [ ] 「強さ順」ボタンで合計値降順ソートが動作する
- [ ] ダメージシミュの敵選択に変化がない
- [ ] `npx tsc --noEmit` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)