### PR TITLE
feat(data): 新武器3件追加（ネギソード・ワタッガシ・滅界双刃）

### DIFF
--- a/docs/data/equipment.json
+++ b/docs/data/equipment.json
@@ -1182,5 +1182,53 @@
     "mov": 0,
     "special": null,
     "order": 730
+  },
+  {
+    "name": "ネギソード",
+    "slot": "武器",
+    "series": null,
+    "material": "強化できない",
+    "vit": 100,
+    "spd": 0,
+    "atk": 0,
+    "int": 0,
+    "def": 0,
+    "mdef": 0,
+    "luck": 0,
+    "mov": 5,
+    "special": null,
+    "order": 740
+  },
+  {
+    "name": "ワタッガシ",
+    "slot": "武器",
+    "series": null,
+    "material": null,
+    "vit": 0,
+    "spd": 0,
+    "atk": 0,
+    "int": 0,
+    "def": 0,
+    "mdef": 0,
+    "luck": 3999,
+    "mov": 0,
+    "special": "5体攻撃\n攻撃範囲増（小）",
+    "order": 750
+  },
+  {
+    "name": "滅界双刃",
+    "slot": "武器",
+    "series": null,
+    "material": "ホワイドデブリ×1\n引きちぎられた鎖×11",
+    "vit": 0,
+    "spd": 5555,
+    "atk": 0,
+    "int": 0,
+    "def": 0,
+    "mdef": 0,
+    "luck": 0,
+    "mov": 2,
+    "special": "2体攻撃\n攻撃範囲増（中）",
+    "order": 760
   }
 ]


### PR DESCRIPTION
## 変更内容

`docs/data/equipment.json` に新武器3件を末尾追加。

| 武器 | vit | spd | luck | mov | special |
|------|-----|-----|------|-----|---------|
| ネギソード | 100 | 0 | 0 | 5 | — |
| ワタッガシ | 0 | 0 | 3999 | 0 | 5体攻撃 / 攻撃範囲増（小） |
| 滅界双刃 | 0 | 5555 | 0 | 2 | 2体攻撃 / 攻撃範囲増（中） |

## 確認事項

- [x] 末尾追加（既存インデックス変化なし）
- [x] JSON valid 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)