### PR TITLE
feat(i18n): PetSimulator等の英語化（PR1c）

### DIFF
--- a/src/components/AreaPresetModal.tsx
+++ b/src/components/AreaPresetModal.tsx
@@ -129,7 +129,7 @@ export function AreaPresetModal({
                   {group.presets.map((preset, pi) => (
                     <div key={pi} className="flex items-center gap-2 text-xs text-gray-500">
                       <span className="truncate flex-1">
-                        {preset.monsterName ?? "(名称不明)"}
+                        {preset.monsterName ?? t("game:unknownName")}
                       </span>
                       <span className="shrink-0 text-gray-400">
                         Lv{preset.level.toLocaleString()}

--- a/src/components/MonsterEditor.tsx
+++ b/src/components/MonsterEditor.tsx
@@ -372,7 +372,7 @@ export function MonsterEditor() {
                     </span>
                   </div>
                   <div className="text-[10px] text-gray-400 mt-0.5">
-                    EXP: {m.exp.toLocaleString()} / G: {m.gold.toLocaleString()} / 捕獲: {m.captureRate}%
+                    EXP: {m.exp.toLocaleString()} / G: {m.gold.toLocaleString()} / {t("game:captureRateShort")}: {m.captureRate}%
                   </div>
                 </div>
                 <div className="flex gap-1 shrink-0">

--- a/src/components/PetSimulator.tsx
+++ b/src/components/PetSimulator.tsx
@@ -29,15 +29,16 @@ function PetCompareTable({
   resultA: ReturnType<typeof calcPetStats>;
   resultB: ReturnType<typeof calcPetStats>;
 }) {
+  const { t } = useTranslation("pet");
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm border-collapse">
         <thead>
           <tr className="bg-gray-50 text-xs text-gray-500">
-            <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
-            <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">設定 A</th>
-            <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">設定 B</th>
-            <th className="text-right px-3 py-2 border border-gray-100">差分</th>
+            <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">{t("stat")}</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">{t("configA")}</th>
+            <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">{t("configB")}</th>
+            <th className="text-right px-3 py-2 border border-gray-100">{t("diff")}</th>
           </tr>
         </thead>
         <tbody>
@@ -86,18 +87,19 @@ function EquivalentLevelTable({
   eqLevels: Record<StatKey, number | null>;
   currentLevelB: number;
 }) {
+  const { t } = useTranslation("pet");
   return (
     <div className="space-y-2">
       <p className="text-xs text-gray-500">
-        設定 A の各ステータスに、設定 B が追いつく最低レベル
+        {t("catchupNote")}
       </p>
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="bg-gray-50 text-xs text-gray-500">
-              <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">ステータス</th>
-              <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">A の値</th>
-              <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">B の追いつきLv</th>
+              <th className="text-left px-3 py-2 border border-gray-100 sticky left-0 bg-gray-50 z-10">{t("stat")}</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-blue-600">{t("configAValue")}</th>
+              <th className="text-right px-3 py-2 border border-gray-100 text-orange-500">{t("catchupLvB")}</th>
             </tr>
           </thead>
           <tbody>
@@ -111,9 +113,9 @@ function EquivalentLevelTable({
                   <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums text-blue-700 font-medium">{targetVal.toLocaleString()}</td>
                   <td className="px-3 py-1.5 border border-gray-100 text-right tabular-nums font-bold">
                     {eqLv === null ? (
-                      <span className="text-red-400">Lv.1200でも届かない</span>
+                      <span className="text-red-400">{t("cannotReach")}</span>
                     ) : isAlreadyAchieved ? (
-                      <span className="text-green-600">達成済み (Lv.{eqLv.toLocaleString()})</span>
+                      <span className="text-green-600">{t("achieved", { lv: eqLv.toLocaleString() })}</span>
                     ) : (
                       <span className="text-orange-600">Lv.{eqLv.toLocaleString()}</span>
                     )}
@@ -132,6 +134,7 @@ function EquivalentLevelTable({
 
 function PetStatPanel({ result, label }: { result: ReturnType<typeof calcPetStats>; label: string }) {
   const { t: tGame } = useTranslation("game");
+  const { t } = useTranslation("pet");
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
@@ -143,8 +146,8 @@ function PetStatPanel({ result, label }: { result: ReturnType<typeof calcPetStat
       <table className="w-full text-sm border-collapse">
         <thead>
           <tr className="bg-gray-50 text-xs text-gray-500">
-            <th className="text-left px-3 py-2 border border-gray-100">ステータス</th>
-            <th className="text-right px-3 py-2 border border-gray-100">値</th>
+            <th className="text-left px-3 py-2 border border-gray-100">{t("stat")}</th>
+            <th className="text-right px-3 py-2 border border-gray-100">{t("value")}</th>
           </tr>
         </thead>
         <tbody>
@@ -167,6 +170,7 @@ function PetStatPanel({ result, label }: { result: ReturnType<typeof calcPetStat
 // ── Main Component ────────────────────────────────────────────────────────────
 
 export function PetSimulator() {
+  const { t } = useTranslation("pet");
   type PetCfgTuple = [PetDamageConfig, <K extends keyof PetDamageConfig>(field: K, value: PetDamageConfig[K]) => void, () => void, (s: PetDamageConfig) => void];
   const [cfgA, setFieldA, resetA, replaceAllA] = usePersistedGroup<PetDamageConfig & Record<string, unknown>>(
     "pet-sim:a",
@@ -224,7 +228,7 @@ export function PetSimulator() {
                   : "bg-white text-gray-500 hover:bg-gray-50"
               }`}
             >
-              設定 {id}
+              {t("configLabel", { id })}
             </button>
           ))}
         </div>
@@ -245,14 +249,14 @@ export function PetSimulator() {
           <>
             {/* 比較テーブル */}
             <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
-              <h2 className="text-base font-bold text-gray-700">ステータス比較</h2>
+              <h2 className="text-base font-bold text-gray-700">{t("statComparison")}</h2>
               <PetCompareTable resultA={resultA} resultB={resultB} />
             </div>
 
             {/* 追いつきレベル */}
             {showEqLevels && (
               <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
-                <h2 className="text-base font-bold text-gray-700">追いつきレベル（A→B）</h2>
+                <h2 className="text-base font-bold text-gray-700">{t("catchupLevel")}</h2>
                 <EquivalentLevelTable
                   resultA={resultA}
                   eqLevels={eqLevels}
@@ -264,10 +268,10 @@ export function PetSimulator() {
             {/* 個別詳細（比較中も表示） */}
             <div className="grid grid-cols-2 gap-4">
               <div className="bg-blue-50 rounded-xl border border-blue-100 p-4">
-                <PetStatPanel result={resultA} label="設定 A の詳細" />
+                <PetStatPanel result={resultA} label={t("configDetails", { id: "A" })} />
               </div>
               <div className="bg-orange-50 rounded-xl border border-orange-100 p-4">
-                <PetStatPanel result={resultB} label="設定 B の詳細" />
+                <PetStatPanel result={resultB} label={t("configDetails", { id: "B" })} />
               </div>
             </div>
           </>
@@ -276,12 +280,12 @@ export function PetSimulator() {
           <div className="bg-white rounded-xl border border-gray-200 p-4">
             <PetStatPanel
               result={activeResult}
-              label={`設定 ${activeConfig} のステータス`}
+              label={t("configStats", { id: activeConfig })}
             />
           </div>
         ) : (
           <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
-            ペットを選択してください
+            {t("selectPet")}
           </div>
         )}
       </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -10,6 +10,7 @@ import jaFarm from "./locales/ja/farm.json";
 import jaArena from "./locales/ja/arena.json";
 import jaMonsters from "./locales/ja/monsters.json";
 import jaPetBattle from "./locales/ja/petbattle.json";
+import jaPet from "./locales/ja/pet.json";
 
 import enCommon from "./locales/en/common.json";
 import enGame from "./locales/en/game.json";
@@ -19,6 +20,7 @@ import enFarm from "./locales/en/farm.json";
 import enArena from "./locales/en/arena.json";
 import enMonsters from "./locales/en/monsters.json";
 import enPetBattle from "./locales/en/petbattle.json";
+import enPet from "./locales/en/pet.json";
 
 i18n
   .use(LanguageDetector)
@@ -34,6 +36,7 @@ i18n
         arena: jaArena,
         monsters: jaMonsters,
         petbattle: jaPetBattle,
+        pet: jaPet,
       },
       en: {
         common: enCommon,
@@ -44,6 +47,7 @@ i18n
         arena: enArena,
         monsters: enMonsters,
         petbattle: enPetBattle,
+        pet: enPet,
       },
     },
     fallbackLng: "ja",

--- a/src/i18n/locales/en/game.json
+++ b/src/i18n/locales/en/game.json
@@ -50,6 +50,7 @@
   "noMatchingMonsters": "No matching monsters",
   "sortBy": "Sort:",
   "captureRate": "Capture Rate (%)",
+  "captureRateShort": "Cap.",
   "gold": "Gold",
   "accSlot": {
     "1": "Slot 1",

--- a/src/i18n/locales/en/pet.json
+++ b/src/i18n/locales/en/pet.json
@@ -1,0 +1,18 @@
+{
+  "stat": "Stat",
+  "configLabel": "Config {{id}}",
+  "configA": "Config A",
+  "configB": "Config B",
+  "diff": "Diff",
+  "value": "Value",
+  "statComparison": "Stat Comparison",
+  "catchupLevel": "Catch-up Level (A→B)",
+  "catchupNote": "Min. level for Config B to reach each stat of Config A",
+  "configAValue": "Config A",
+  "catchupLvB": "B Catch-up Lv",
+  "cannotReach": "Can't reach by Lv.1200",
+  "achieved": "Achieved (Lv.{{lv}})",
+  "configDetails": "Config {{id}} Details",
+  "configStats": "Config {{id}} Stats",
+  "selectPet": "Select a pet"
+}

--- a/src/i18n/locales/ja/game.json
+++ b/src/i18n/locales/ja/game.json
@@ -50,6 +50,7 @@
   "noMatchingMonsters": "該当するモンスターがいません",
   "sortBy": "並び替え:",
   "captureRate": "捕獲率(%)",
+  "captureRateShort": "捕獲",
   "gold": "ゴールド",
   "accSlot": {
     "1": "スロット1",

--- a/src/i18n/locales/ja/pet.json
+++ b/src/i18n/locales/ja/pet.json
@@ -1,0 +1,18 @@
+{
+  "stat": "ステータス",
+  "configLabel": "設定 {{id}}",
+  "configA": "設定 A",
+  "configB": "設定 B",
+  "diff": "差分",
+  "value": "値",
+  "statComparison": "ステータス比較",
+  "catchupLevel": "追いつきレベル（A→B）",
+  "catchupNote": "設定 A の各ステータスに、設定 B が追いつく最低レベル",
+  "configAValue": "A の値",
+  "catchupLvB": "B の追いつきLv",
+  "cannotReach": "Lv.1200でも届かない",
+  "achieved": "達成済み (Lv.{{lv}})",
+  "configDetails": "設定 {{id}} の詳細",
+  "configStats": "設定 {{id}} のステータス",
+  "selectPet": "ペットを選択してください"
+}


### PR DESCRIPTION
## 変更内容

- **PetSimulator**: `pet` namespaceを新規作成し、全日本語UIを`t()`化
  - 比較テーブルのヘッダー（ステータス・設定A/B・差分）
  - 追いつきレベルテーブル（説明文・A の値・B の追いつきLv・達成済み/未達メッセージ）
  - 設定タブ・各セクションタイトル
- **MonsterEditor**: `game:captureRateShort`キー追加で一覧の「捕獲」表示を英語化（`Cap.`）
- **AreaPresetModal**: `(名称不明)` → 既存の`game:unknownName`キーを活用

## スコープ確認

PR1cの他の対象ファイル（ArenaCalculator, FarmCalculator, ExpCalculator, GoldCalculator, PetBattleSimulator, StatusSimulator, PatchNotesModal, MonsterPickerModal, TabNav, MonsterSelector）は既に`t()`対応済みであることを確認。

## 確認事項

- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功
- [x] 型値（`"物理"/"魔攻"`等）は変更せず表示層のみ翻訳

🤖 Generated with [Claude Code](https://claude.com/claude-code)