### PR TITLE
feat(i18n): monsters.json に nameEn 追加・モンスター名英語表示対応（PR2）

### DIFF
--- a/docs/data/monsters.json
+++ b/docs/data/monsters.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "グリーンスライム",
+    "nameEn": "Green Slime",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -18,6 +19,7 @@
   },
   {
     "name": "レッドゴブリン",
+    "nameEn": "Red Goblin",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -35,6 +37,7 @@
   },
   {
     "name": "ゴブリンメイジ",
+    "nameEn": "Goblin Mage",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -52,6 +55,7 @@
   },
   {
     "name": "クリーチャーローズ",
+    "nameEn": "Creature Rose",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -69,6 +73,7 @@
   },
   {
     "name": "キメラタートル",
+    "nameEn": "Chimera Turtle",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -86,6 +91,7 @@
   },
   {
     "name": "鉄罠花",
+    "nameEn": "Iron Trap Bloom",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -103,6 +109,7 @@
   },
   {
     "name": "ペンギンソルジャー",
+    "nameEn": "Penguin Soldier",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -120,6 +127,7 @@
   },
   {
     "name": "ハネスライム",
+    "nameEn": "Winged Slime",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -137,6 +145,7 @@
   },
   {
     "name": "ボスゴブリン",
+    "nameEn": "Boss Goblin",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -154,6 +163,7 @@
   },
   {
     "name": "ギガントオーク",
+    "nameEn": "Gigant Oak",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -171,6 +181,7 @@
   },
   {
     "name": "古代魚ザコーン",
+    "nameEn": "Ancient Fish Zakorn",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -188,6 +199,7 @@
   },
   {
     "name": "禁域のラミア",
+    "nameEn": "Forbidden Lamia",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -205,6 +217,7 @@
   },
   {
     "name": "マッドガエル",
+    "nameEn": "Mad Frog",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -222,6 +235,7 @@
   },
   {
     "name": "ダークメイジ",
+    "nameEn": "Dark Mage",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -239,6 +253,7 @@
   },
   {
     "name": "アリクイロード",
+    "nameEn": "Anteater Lord",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -256,6 +271,7 @@
   },
   {
     "name": "原始蝶",
+    "nameEn": "Primitive Butterfly",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -273,6 +289,7 @@
   },
   {
     "name": "動く墓",
+    "nameEn": "Walking Grave",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -290,6 +307,7 @@
   },
   {
     "name": "オルトロス",
+    "nameEn": "Orthros",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -307,6 +325,7 @@
   },
   {
     "name": "雪だるまん",
+    "nameEn": "Snowdarman",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -324,6 +343,7 @@
   },
   {
     "name": "シカファイター",
+    "nameEn": "Deer Fighter",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -341,6 +361,7 @@
   },
   {
     "name": "ペンギンロード",
+    "nameEn": "Penguin Lord",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -358,6 +379,7 @@
   },
   {
     "name": "パンダ",
+    "nameEn": "Panda",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -375,6 +397,7 @@
   },
   {
     "name": "ファントムツリー",
+    "nameEn": "Phantom Tree",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -392,6 +415,7 @@
   },
   {
     "name": "スノーモケラ",
+    "nameEn": "Snow Mokera",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -409,6 +433,7 @@
   },
   {
     "name": "零の者",
+    "nameEn": "The One of Zero",
     "level": 0,
     "element": "水",
     "attackType": "魔弾",
@@ -426,6 +451,7 @@
   },
   {
     "name": "禁域の巨木",
+    "nameEn": "Forbidden Treant",
     "level": 0,
     "element": "木",
     "attackType": "魔弾",
@@ -443,6 +469,7 @@
   },
   {
     "name": "ゴブリン特攻隊",
+    "nameEn": "Goblin Assault Unit",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -460,6 +487,7 @@
   },
   {
     "name": "ゴブリンクルー",
+    "nameEn": "Goblin Crew",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -477,6 +505,7 @@
   },
   {
     "name": "紅サソリ",
+    "nameEn": "Crimson Scorpion",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -494,6 +523,7 @@
   },
   {
     "name": "死戦士マミー",
+    "nameEn": "Death Warrior Mummy",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -511,6 +541,7 @@
   },
   {
     "name": "アヌビス",
+    "nameEn": "Anubis",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -528,6 +559,7 @@
   },
   {
     "name": "ファイヤーメイジ",
+    "nameEn": "Fire Mage",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -545,6 +577,7 @@
   },
   {
     "name": "エジプトアシュラ",
+    "nameEn": "Egypt Ashura",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -562,6 +595,7 @@
   },
   {
     "name": "デザートイッヌ",
+    "nameEn": "Desert Doggo",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -579,6 +613,7 @@
   },
   {
     "name": "不思議なツボ",
+    "nameEn": "Mysterious Jar",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -596,6 +631,7 @@
   },
   {
     "name": "天狗",
+    "nameEn": "Tengu",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -613,6 +649,7 @@
   },
   {
     "name": "ランプの精霊",
+    "nameEn": "Lamp Spirit",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -630,6 +667,7 @@
   },
   {
     "name": "邪黒竜",
+    "nameEn": "Dark Dragon",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -647,6 +685,7 @@
   },
   {
     "name": "捧げし者",
+    "nameEn": "The Devoted One",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -664,6 +703,7 @@
   },
   {
     "name": "黎明神トモダチ",
+    "nameEn": "Dawn God Tomodachi",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -681,6 +721,7 @@
   },
   {
     "name": "禁域のアヌビシュ",
+    "nameEn": "Forbidden Anubish",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -698,6 +739,7 @@
   },
   {
     "name": "居住者A",
+    "nameEn": "Resident A",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -715,6 +757,7 @@
   },
   {
     "name": "居住者B",
+    "nameEn": "Resident B",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -732,6 +775,7 @@
   },
   {
     "name": "ホネ",
+    "nameEn": "Bone",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -749,6 +793,7 @@
   },
   {
     "name": "ボーンバトラー",
+    "nameEn": "Bone Battler",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -766,6 +811,7 @@
   },
   {
     "name": "ダイコンに見えるダイコン",
+    "nameEn": "Radish That Looks Like a Radish",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -783,6 +829,7 @@
   },
   {
     "name": "クリーチャーアイ",
+    "nameEn": "Creature Eye",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -800,6 +847,7 @@
   },
   {
     "name": "悪夢の石像",
+    "nameEn": "Nightmare Statue",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -817,6 +865,7 @@
   },
   {
     "name": "スカルウィスプ",
+    "nameEn": "Skull Wisp",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -834,6 +883,7 @@
   },
   {
     "name": "フレイムフロッグ",
+    "nameEn": "Flame Frog",
     "level": 0,
     "element": "火",
     "attackType": "魔法",
@@ -851,6 +901,7 @@
   },
   {
     "name": "キメラキング",
+    "nameEn": "Chimera King",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -868,6 +919,7 @@
   },
   {
     "name": "ネクロプリンセス",
+    "nameEn": "Necro Princess",
     "level": 0,
     "element": "闇",
     "attackType": "魔法",
@@ -885,6 +937,7 @@
   },
   {
     "name": "朽ちざる竜骸イゾ",
+    "nameEn": "Undying Dragon Corpse Izo",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -902,6 +955,7 @@
   },
   {
     "name": "禁域のクマヌイ",
+    "nameEn": "Forbidden Bear",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -919,6 +973,7 @@
   },
   {
     "name": "烈火鼠",
+    "nameEn": "Blaze Mouse",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -936,6 +991,7 @@
   },
   {
     "name": "燃えてる何か",
+    "nameEn": "Burning Something",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -953,6 +1009,7 @@
   },
   {
     "name": "焼トリ",
+    "nameEn": "Grilled Bird",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -970,6 +1027,7 @@
   },
   {
     "name": "ウォーデン",
+    "nameEn": "Warden",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -987,6 +1045,7 @@
   },
   {
     "name": "バーニングロック",
+    "nameEn": "Burning Rock",
     "level": 0,
     "element": "火",
     "attackType": "魔法",
@@ -1004,6 +1063,7 @@
   },
   {
     "name": "ケルベロス",
+    "nameEn": "Cerberus",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1021,6 +1081,7 @@
   },
   {
     "name": "ガチキメラ",
+    "nameEn": "True Chimera",
     "level": 0,
     "element": "火",
     "attackType": "魔法",
@@ -1038,6 +1099,7 @@
   },
   {
     "name": "フレイムボーン",
+    "nameEn": "Flame Bone",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -1055,6 +1117,7 @@
   },
   {
     "name": "炎鬼",
+    "nameEn": "Flame Ogre",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1072,6 +1135,7 @@
   },
   {
     "name": "ブタ天使",
+    "nameEn": "Pig Angel",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1089,6 +1153,7 @@
   },
   {
     "name": "エレファントパラディン",
+    "nameEn": "Elephant Paladin",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1106,6 +1171,7 @@
   },
   {
     "name": "赫竜王",
+    "nameEn": "Infernal Dragon",
     "level": 0,
     "element": "火",
     "attackType": "魔法",
@@ -1123,6 +1189,7 @@
   },
   {
     "name": "残燃モエコ",
+    "nameEn": "Smoldering Moeko",
     "level": 0,
     "element": "火",
     "attackType": "魔法",
@@ -1140,6 +1207,7 @@
   },
   {
     "name": "禁域のヴァルネシア",
+    "nameEn": "Forbidden Valnesia",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1157,6 +1225,7 @@
   },
   {
     "name": "カニクラブ",
+    "nameEn": "Crab Club",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1174,6 +1243,7 @@
   },
   {
     "name": "ワニゲーター",
+    "nameEn": "Gator Crocodile",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1191,6 +1261,7 @@
   },
   {
     "name": "翡翠竜",
+    "nameEn": "Jade Dragon",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -1208,6 +1279,7 @@
   },
   {
     "name": "マッドシャーク",
+    "nameEn": "Mad Shark",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1225,6 +1297,7 @@
   },
   {
     "name": "浮遊イカ",
+    "nameEn": "Floating Squid",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -1242,6 +1315,7 @@
   },
   {
     "name": "氷結晶",
+    "nameEn": "Ice Crystal",
     "level": 0,
     "element": "水",
     "attackType": "魔弾",
@@ -1259,6 +1333,7 @@
   },
   {
     "name": "命を刈り取る者",
+    "nameEn": "The Reaper of Life",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1276,6 +1351,7 @@
   },
   {
     "name": "ヤマタノオロチ",
+    "nameEn": "Yamata no Orochi",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -1293,6 +1369,7 @@
   },
   {
     "name": "元ギルド長ノック",
+    "nameEn": "Former Guild Master",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1310,6 +1387,7 @@
   },
   {
     "name": "ラッキーヒトデ",
+    "nameEn": "Lucky Starfish",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1327,6 +1405,7 @@
   },
   {
     "name": "アビスマーダー",
+    "nameEn": "Abyss Murderer",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -1344,6 +1423,7 @@
   },
   {
     "name": "氷女王アナトユ",
+    "nameEn": "Ice Queen Anatoyu",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -1361,6 +1441,7 @@
   },
   {
     "name": "封印されし神鯨",
+    "nameEn": "Divine Whale",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1378,6 +1459,7 @@
   },
   {
     "name": "超越者リガミア",
+    "nameEn": "Rigamia",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -1395,6 +1477,7 @@
   },
   {
     "name": "海賊船",
+    "nameEn": "Pirate Ship",
     "level": 0,
     "element": "水",
     "attackType": "魔弾",
@@ -1412,6 +1495,7 @@
   },
   {
     "name": "ホムラウマ",
+    "nameEn": "Blaze Steed",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1429,6 +1513,7 @@
   },
   {
     "name": "深淵灯魚",
+    "nameEn": "Abyss Lanternfish",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -1446,6 +1531,7 @@
   },
   {
     "name": "うねうね",
+    "nameEn": "Uneune",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -1463,6 +1549,7 @@
   },
   {
     "name": "イージスリエル",
+    "nameEn": "Aegisriel",
     "level": 0,
     "element": "光",
     "attackType": "魔弾",
@@ -1480,6 +1567,7 @@
   },
   {
     "name": "デーモンブレイド",
+    "nameEn": "Demonblade",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -1497,6 +1585,7 @@
   },
   {
     "name": "時空竜クロノゼリウス",
+    "nameEn": "ChronoZelius",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -1514,6 +1603,7 @@
   },
   {
     "name": "マルコゲトカゲ",
+    "nameEn": "Charred Lizard",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1531,6 +1621,7 @@
   },
   {
     "name": "白竜",
+    "nameEn": "Albion Dragon",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1548,6 +1639,7 @@
   },
   {
     "name": "イグニス・シスター",
+    "nameEn": "Ignis Sister",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -1565,6 +1657,7 @@
   },
   {
     "name": "オルド・クラウセス",
+    "nameEn": "Ordo Krausus",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1582,6 +1675,7 @@
   },
   {
     "name": "BOX",
+    "nameEn": "BOX",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1599,6 +1693,7 @@
   },
   {
     "name": "冥王ノクタール",
+    "nameEn": "Noctar",
     "level": 0,
     "element": "闇",
     "attackType": "魔法",
@@ -1616,6 +1711,7 @@
   },
   {
     "name": "罪環の監視者モルモ",
+    "nameEn": "Warden of Sin-Cycle",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1633,6 +1729,7 @@
   },
   {
     "name": "ダークウィッチ",
+    "nameEn": "Dark Witch",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -1650,6 +1747,7 @@
   },
   {
     "name": "冥炎のハデス",
+    "nameEn": "Hades",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1667,6 +1765,7 @@
   },
   {
     "name": "イグニシア",
+    "nameEn": "Ignisia",
     "level": 0,
     "element": "火",
     "attackType": "魔弾",
@@ -1684,6 +1783,7 @@
   },
   {
     "name": "ヌー",
+    "nameEn": "Nuu",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1701,6 +1801,7 @@
   },
   {
     "name": "ミニハム",
+    "nameEn": "Mossyham",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -1718,6 +1819,7 @@
   },
   {
     "name": "シーサー",
+    "nameEn": "Shinelion",
     "level": 0,
     "element": "光",
     "attackType": "魔法",
@@ -1735,6 +1837,7 @@
   },
   {
     "name": "グルームエッグ",
+    "nameEn": "GloomEgg",
     "level": 0,
     "element": "闇",
     "attackType": "魔弾",
@@ -1752,6 +1855,7 @@
   },
   {
     "name": "スライムガール(物理)",
+    "nameEn": "Slime Girl (P)",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -1769,6 +1873,7 @@
   },
   {
     "name": "スライムガール(魔法)",
+    "nameEn": "Slime Girl (M)",
     "level": 0,
     "element": "木",
     "attackType": "魔法",
@@ -1786,6 +1891,7 @@
   },
   {
     "name": "ペリカンEXP",
+    "nameEn": "Pelican EXP",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1803,6 +1909,7 @@
   },
   {
     "name": "支配のトリ",
+    "nameEn": "Bird of Domination",
     "level": 0,
     "element": "闇",
     "attackType": "魔法",
@@ -1820,6 +1927,7 @@
   },
   {
     "name": "キングニワトリ",
+    "nameEn": "Chicken King",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1837,6 +1945,7 @@
   },
   {
     "name": "虹ペリカンEXP",
+    "nameEn": "Rainbow Pelican EXP",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1854,6 +1963,7 @@
   },
   {
     "name": "禁域のワイバーン",
+    "nameEn": "Forbidden Wyvern",
     "level": 0,
     "element": "水",
     "attackType": "物理",
@@ -1871,6 +1981,7 @@
   },
   {
     "name": "グラビティスライム",
+    "nameEn": "Gravity Slime",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -1888,6 +1999,7 @@
   },
   {
     "name": "ドラゴンヘッド",
+    "nameEn": "Dragon Head",
     "level": 0,
     "element": "火",
     "attackType": "物理",
@@ -1905,6 +2017,7 @@
   },
   {
     "name": "黙示木",
+    "nameEn": "Apocalypse Tree",
     "level": 0,
     "element": "木",
     "attackType": "魔弾",
@@ -1922,6 +2035,7 @@
   },
   {
     "name": "雷大王イカ",
+    "nameEn": "Thunder King Squid",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -1939,6 +2053,7 @@
   },
   {
     "name": "ダークフェニックス",
+    "nameEn": "Dark Phoenix",
     "level": 0,
     "element": "闇",
     "attackType": "魔法",
@@ -1956,6 +2071,7 @@
   },
   {
     "name": "オコシイタケ",
+    "nameEn": "Angry Shiitake",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -1973,6 +2089,7 @@
   },
   {
     "name": "オコスター",
+    "nameEn": "Angry Star",
     "level": 0,
     "element": "木",
     "attackType": "魔弾",
@@ -1990,6 +2107,7 @@
   },
   {
     "name": "動く石碑",
+    "nameEn": "Walking Stone",
     "level": 0,
     "element": "闇",
     "attackType": "物理",
@@ -2008,6 +2126,7 @@
   },
   {
     "name": "トリカゴドリ",
+    "nameEn": "Cagebird",
     "level": 0,
     "element": "水",
     "attackType": "魔法",
@@ -2025,6 +2144,7 @@
   },
   {
     "name": "鉄壁要塞パルテノン",
+    "nameEn": "Parthenon",
     "level": 0,
     "element": "光",
     "attackType": "物理",
@@ -2042,6 +2162,7 @@
   },
   {
     "name": "根界獣ドルグラント",
+    "nameEn": "Dolgrant",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -2060,6 +2181,7 @@
   },
   {
     "name": "オコォーン",
+    "nameEn": "Angry Corn",
     "level": 0,
     "element": "木",
     "attackType": "物理",
@@ -2077,6 +2199,7 @@
   },
   {
     "name": "オメガ・スペクトラム",
+    "nameEn": "Omega Spectrum",
     "level": 0,
     "element": "闇",
     "attackType": "魔法",

--- a/src/components/AreaPresetModal.tsx
+++ b/src/components/AreaPresetModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { enemyPresetGroups } from "../data/enemyPresets";
-import { getMonsterByName } from "../data/monsters";
+import { getMonsterByName, getMonsterDisplayName } from "../data/monsters";
 import { getMonsterDropInfo } from "../data/monsterDrops";
 import type { MonsterBase } from "../types/game";
 
@@ -31,7 +31,8 @@ export function AreaPresetModal({
   onPickGroup: (entries: AreaMonsterEntry[]) => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation("farm");
+  const { t, i18n } = useTranslation("farm");
+  const lang = i18n.language;
   const [selectedMap, setSelectedMap] = useState<string>(mapLabels[0] ?? "");
 
   useEffect(() => {
@@ -129,7 +130,10 @@ export function AreaPresetModal({
                   {group.presets.map((preset, pi) => (
                     <div key={pi} className="flex items-center gap-2 text-xs text-gray-500">
                       <span className="truncate flex-1">
-                        {preset.monsterName ?? t("game:unknownName")}
+                        {(() => {
+                          const m = preset.monsterName ? getMonsterByName(preset.monsterName) : null;
+                          return m ? getMonsterDisplayName(m, lang) : (preset.monsterName ?? t("game:unknownName"));
+                        })()}
                       </span>
                       <span className="shrink-0 text-gray-400">
                         Lv{preset.level.toLocaleString()}

--- a/src/components/AreaPresetModal.tsx
+++ b/src/components/AreaPresetModal.tsx
@@ -15,13 +15,19 @@ export interface AreaMonsterEntry {
   superRareDrop: string;
 }
 
-// mapLabel ごとにグルーピング
+// mapLabel ごとにグルーピング（キーはJA固定でIDとして使用）
 const mapLabels = [...new Set(enemyPresetGroups.map((g) => g.mapLabel))];
 const groupsByMap = new Map(
   mapLabels.map((label) => [
     label,
     enemyPresetGroups.filter((g) => g.mapLabel === label),
   ])
+);
+// mapLabel(JA) → mapLabelEn のルックアップ
+const mapLabelEnMap = new Map(
+  enemyPresetGroups
+    .filter((g) => g.mapLabelEn)
+    .map((g) => [g.mapLabel, g.mapLabelEn!])
 );
 
 export function AreaPresetModal({
@@ -108,7 +114,7 @@ export function AreaPresetModal({
                     : "text-gray-600 hover:bg-gray-50"
                 }`}
               >
-                {label}
+                {lang === "en" ? (mapLabelEnMap.get(label) ?? label) : label}
               </button>
             ))}
           </div>
@@ -118,7 +124,9 @@ export function AreaPresetModal({
             {groups.map((group, idx) => (
               <div key={idx} className="bg-gray-50 rounded-xl p-3">
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-xs font-semibold text-gray-700">{group.label}</span>
+                  <span className="text-xs font-semibold text-gray-700">
+                    {lang === "en" ? (group.labelEn ?? group.label) : group.label}
+                  </span>
                   <button
                     onClick={() => handlePickGroup(idx)}
                     className="px-2.5 py-1 bg-indigo-500 text-white text-xs font-medium rounded-lg hover:bg-indigo-600 transition-colors"

--- a/src/components/ArenaCalculator.tsx
+++ b/src/components/ArenaCalculator.tsx
@@ -12,7 +12,7 @@ import {
 } from "../utils/defenseCalc";
 import { calcMultiHitCount, calcPhysicalDamage, calcHitRate } from "../utils/damageCalc";
 import { calcStatus } from "../utils/statusCalc";
-import { getMonsterByName } from "../data/monsters";
+import { getMonsterByName, getMonsterDisplayName } from "../data/monsters";
 import { InputField } from "./ui/InputField";
 import type { MonsterBase, ScaledMonster } from "../types/game";
 import type { TFunction } from "i18next";
@@ -192,7 +192,7 @@ function ArenaMonsterRow({ result, onLevelClick, t, lang }: { result: ArenaResul
   return (
     <tr className={`border-b ${rowBg} text-sm`}>
       <td className="px-2 py-1.5 font-medium text-gray-800 whitespace-nowrap">
-        {result.base.name}
+        {getMonsterDisplayName(result.base, lang)}
       </td>
       <td className="px-2 py-1.5 whitespace-nowrap">
         <span

--- a/src/components/FarmCalculator.tsx
+++ b/src/components/FarmCalculator.tsx
@@ -472,7 +472,7 @@ export function FarmCalculator() {
                         {preset.name}
                       </span>
                       <span className="text-[10px] text-gray-400 shrink-0">
-                        {preset.rows.length}体
+                        {t("monsterCount", { count: preset.rows.length })}
                       </span>
                       <button
                         onClick={() => loadPreset(preset)}

--- a/src/components/FarmCalculator.tsx
+++ b/src/components/FarmCalculator.tsx
@@ -14,7 +14,7 @@ import {
   type MonsterGoldEntry,
 } from "../utils/goldCalc";
 import { getMonsterDropInfo } from "../data/monsterDrops";
-import { getMonsterByName } from "../data/monsters";
+import { getMonsterByName, getMonsterDisplayName } from "../data/monsters";
 import { usePersistedState } from "../hooks/usePersistedState";
 import { StatCard } from "./ui/StatCard";
 import { MonsterPickerModal } from "./MonsterPickerModal";
@@ -107,7 +107,8 @@ function fmtDrop(n: number): string {
 }
 
 export function FarmCalculator() {
-  const { t } = useTranslation("farm");
+  const { t, i18n } = useTranslation("farm");
+  const lang = i18n.language;
   const [monsterRows, setMonsterRows] = useState<MonsterRow[]>([]);
   const [secondsPerRun, setSecondsPerRun] = usePersistedState("farm:seconds", "60");
   const [expBonus, setExpBonus] = usePersistedState("farm:expBonus", "0");
@@ -346,7 +347,7 @@ export function FarmCalculator() {
                 <div key={row.id} className="py-2 px-3 bg-gray-50 rounded-lg space-y-2">
                   {/* 名前 + 削除 */}
                   <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-gray-700 truncate">{row.monster.name}</span>
+                    <span className="text-sm font-medium text-gray-700 truncate">{getMonsterDisplayName(row.monster, lang)}</span>
                     <button onClick={() => removeMonster(row.id)} className="text-gray-400 hover:text-red-500 transition-colors shrink-0 ml-2">
                       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/src/components/MonsterPickerModal.tsx
+++ b/src/components/MonsterPickerModal.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { MonsterBase } from "../types/game";
 import { useAllMonsters } from "../hooks/useAllMonsters";
+import { getMonsterDisplayName } from "../data/monsters";
 
 type SortKey = "exp_desc" | "exp_asc" | "gold_desc" | "gold_asc";
 
@@ -20,7 +21,8 @@ export function MonsterPickerModal({
   onPick: (monster: MonsterBase) => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation("monsters");
+  const { t, i18n } = useTranslation("monsters");
+  const lang = i18n.language;
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<SortKey>("exp_desc");
 
@@ -30,7 +32,11 @@ export function MonsterPickerModal({
     let list = allMonsters;
     if (query) {
       const lower = query.toLowerCase();
-      list = list.filter((m) => m.name.toLowerCase().includes(lower));
+      list = list.filter((m) => {
+        if (m.name.toLowerCase().includes(lower)) return true;
+        if (lang === "en" && m.nameEn && m.nameEn.toLowerCase().includes(lower)) return true;
+        return false;
+      });
     }
     const [key, dir] = sort.split("_") as ["exp" | "gold", "desc" | "asc"];
     return [...list].sort((a, b) => {
@@ -116,7 +122,7 @@ export function MonsterPickerModal({
             >
               <div className="flex items-center gap-2 min-w-0">
                 <span className="text-sm text-gray-800 truncate">
-                  {monster.name}
+                  {getMonsterDisplayName(monster, lang)}
                 </span>
                 <span
                   className={`text-xs px-1.5 py-0.5 rounded shrink-0 ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}

--- a/src/components/ui/EnemyPresetModal.tsx
+++ b/src/components/ui/EnemyPresetModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { EnemyPresetGroup, EnemyPreset } from "../../data/enemyPresets";
+import { getMonsterByName, getMonsterDisplayName } from "../../data/monsters";
 
 /** 比較リスト内のエントリを一意に識別するキー */
 function presetKey(preset: EnemyPreset): string {
@@ -27,7 +28,8 @@ export function EnemyPresetModal({
   isOpen, groups, onClose, onSelect,
   comparisonKeys, onToggleComparison, onConfirmComparison, comparisonCount = 0,
 }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
   const maps = useMemo(() => Array.from(new Set(groups.map(g => g.mapLabel))), [groups]);
   const [selectedMap, setSelectedMap] = useState(() => maps[0] ?? "");
   const [selectedGroupIdx, setSelectedGroupIdx] = useState(0);
@@ -94,12 +96,15 @@ export function EnemyPresetModal({
 
         {/* Mobile: マップピル */}
         <div className="sm:hidden flex overflow-x-auto gap-2 px-4 py-2 border-b border-gray-200 bg-gray-50 flex-shrink-0">
-          {maps.map(map => (
-            <button key={map} onClick={() => handleMapSelect(map)}
-              className={`flex-shrink-0 px-3 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap ${selectedMap === map ? "bg-indigo-600 text-white" : "bg-white text-gray-700 border border-gray-200"}`}>
-              {map}
-            </button>
-          ))}
+          {maps.map(map => {
+            const mapEn = groups.find(g => g.mapLabel === map)?.mapLabelEn;
+            return (
+              <button key={map} onClick={() => handleMapSelect(map)}
+                className={`flex-shrink-0 px-3 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap ${selectedMap === map ? "bg-indigo-600 text-white" : "bg-white text-gray-700 border border-gray-200"}`}>
+                {lang === "en" ? (mapEn ?? map) : map}
+              </button>
+            );
+          })}
         </div>
 
         {/* Mobile: エリアピル */}
@@ -107,7 +112,7 @@ export function EnemyPresetModal({
           {mapGroups.map(g => (
             <button key={g.globalIdx} onClick={() => setSelectedGroupIdx(g.globalIdx)}
               className={`flex-shrink-0 px-3 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap ${selectedGroupIdx === g.globalIdx ? "bg-indigo-600 text-white" : "bg-white text-gray-700 border border-gray-200"}`}>
-              {g.label}
+              {lang === "en" ? (g.labelEn ?? g.label) : g.label}
             </button>
           ))}
         </div>
@@ -117,12 +122,15 @@ export function EnemyPresetModal({
 
           {/* PC: マップ列 */}
           <div className="hidden sm:flex flex-col w-28 flex-shrink-0 bg-gray-50 border-r border-gray-200 overflow-y-auto py-2" style={{ scrollbarGutter: "stable" }}>
-            {maps.map(map => (
-              <button key={map} onClick={() => handleMapSelect(map)}
-                className={`w-full text-left px-3 py-2.5 text-xs font-medium transition-colors ${selectedMap === map ? "bg-white text-indigo-600 border-r-2 border-indigo-500 shadow-sm" : "text-gray-700 hover:bg-gray-100"}`}>
-                {map}
-              </button>
-            ))}
+            {maps.map(map => {
+              const mapEn = groups.find(g => g.mapLabel === map)?.mapLabelEn;
+              return (
+                <button key={map} onClick={() => handleMapSelect(map)}
+                  className={`w-full text-left px-3 py-2.5 text-xs font-medium transition-colors ${selectedMap === map ? "bg-white text-indigo-600 border-r-2 border-indigo-500 shadow-sm" : "text-gray-700 hover:bg-gray-100"}`}>
+                  {lang === "en" ? (mapEn ?? map) : map}
+                </button>
+              );
+            })}
           </div>
 
           {/* PC: エリア列 */}
@@ -130,7 +138,7 @@ export function EnemyPresetModal({
             {mapGroups.map(g => (
               <button key={g.globalIdx} onClick={() => setSelectedGroupIdx(g.globalIdx)}
                 className={`w-full text-left px-3 py-2.5 text-xs font-medium transition-colors ${selectedGroupIdx === g.globalIdx ? "bg-white text-indigo-700 border-r-2 border-indigo-400" : "text-gray-700 hover:bg-gray-100"}`}>
-                {g.label}
+                {lang === "en" ? (g.labelEn ?? g.label) : g.label}
               </button>
             ))}
           </div>
@@ -176,7 +184,7 @@ export function EnemyPresetModal({
                       </span>
                     )}
                     <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 flex items-center gap-1.5">
-                      {preset.monsterName ?? t("game:unknownName")}
+                      {(() => { const m = preset.monsterName ? getMonsterByName(preset.monsterName) : null; return m ? getMonsterDisplayName(m, lang) : (preset.monsterName ?? t("game:unknownName")); })()}
                       {preset.magicImmune && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-600 font-bold flex-shrink-0">{t("damage:magicImmune")}</span>
                       )}
@@ -200,7 +208,7 @@ export function EnemyPresetModal({
                     )}
                     <div className="min-w-0 flex-1">
                       <div className="font-semibold text-gray-900 text-sm group-hover:text-indigo-700 flex items-center gap-1.5">
-                        {preset.monsterName ?? t("game:unknownName")}
+                        {(() => { const m = preset.monsterName ? getMonsterByName(preset.monsterName) : null; return m ? getMonsterDisplayName(m, lang) : (preset.monsterName ?? t("game:unknownName")); })()}
                         {preset.magicImmune && (
                           <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-600 font-bold flex-shrink-0">{t("damage:magicImmune")}</span>
                         )}

--- a/src/components/ui/MonsterSelectorModal.tsx
+++ b/src/components/ui/MonsterSelectorModal.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { MonsterBase, Element } from "../../types/game";
 import { useAllMonsters } from "../../hooks/useAllMonsters";
+import { getMonsterDisplayName } from "../../data/monsters";
 
 type SortKey = "default" | "total" | "atk" | "int" | "vit" | "def" | "mdef" | "spd" | "luck";
 
@@ -80,7 +81,8 @@ interface Props {
 }
 
 export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }: Props) {
-  const { t } = useTranslation(["game", "monsters", "common"]);
+  const { t, i18n } = useTranslation(["game", "monsters", "common"]);
+  const lang = i18n.language;
   const [elementFilter, setElementFilter] = useState<ElementFilter>("all");
   const [query, setQuery] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("default");
@@ -101,7 +103,11 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
     }
     if (query.trim()) {
       const lower = query.toLowerCase();
-      list = list.filter((m) => m.name.toLowerCase().includes(lower));
+      list = list.filter((m) => {
+        if (m.name.toLowerCase().includes(lower)) return true;
+        if (lang === "en" && m.nameEn && m.nameEn.toLowerCase().includes(lower)) return true;
+        return false;
+      });
     }
     if (showPetStats && sortKey !== "default") {
       list = [...list].sort((a, b) => getSortValue(b, sortKey) - getSortValue(a, sortKey));
@@ -231,7 +237,7 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
                     <div className="hidden sm:block">
                       <div className="flex items-center gap-3">
                         <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
-                          {monster.name}
+                          {getMonsterDisplayName(monster, lang)}
                         </span>
                         <span className={`w-14 text-center text-xs px-2 py-0.5 rounded-full font-medium ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
                           {t(`game:element.${monster.element}`)}
@@ -245,7 +251,7 @@ export function MonsterSelectorModal({ isOpen, onClose, onSelect, showPetStats }
                     <div className="sm:hidden">
                       <div className="flex items-center gap-2">
                         <span className="flex-1 font-semibold text-gray-900 text-sm group-hover:text-indigo-700 transition-colors">
-                          {monster.name}
+                          {getMonsterDisplayName(monster, lang)}
                         </span>
                         <span className={`text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${elementColors[monster.element] ?? "bg-gray-100 text-gray-500"}`}>
                           {t(`game:element.${monster.element}`)}

--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -7,7 +7,9 @@ export interface EnemyPreset {
 
 export interface EnemyPresetGroup {
   mapLabel: string;  // マップ名
+  mapLabelEn?: string;
   label: string;
+  labelEn?: string;
   presets: EnemyPreset[];
 }
 

--- a/src/data/monsters.ts
+++ b/src/data/monsters.ts
@@ -43,8 +43,16 @@ export function getAllMonsterNames(): string[] {
   return _all.map((m) => m.name);
 }
 
-export function searchMonsters(query: string): MonsterBase[] {
+export function searchMonsters(query: string, lang?: string): MonsterBase[] {
   if (!query) return _all;
   const lower = query.toLowerCase();
-  return _all.filter((m) => m.name.toLowerCase().includes(lower));
+  return _all.filter((m) => {
+    if (m.name.toLowerCase().includes(lower)) return true;
+    if (lang === "en" && m.nameEn && m.nameEn.toLowerCase().includes(lower)) return true;
+    return false;
+  });
+}
+
+export function getMonsterDisplayName(m: MonsterBase, lang: string): string {
+  return lang === "en" && m.nameEn ? m.nameEn : m.name;
 }

--- a/src/i18n/locales/en/farm.json
+++ b/src/i18n/locales/en/farm.json
@@ -35,5 +35,6 @@
   "loadPreset": "Load",
   "deletePreset": "Delete",
   "presetNamePlaceholder": "Enter preset name",
-  "noSavedPresets": "No saved presets"
+  "noSavedPresets": "No saved presets",
+  "monsterCount": "{{count}} monsters"
 }

--- a/src/i18n/locales/ja/farm.json
+++ b/src/i18n/locales/ja/farm.json
@@ -35,5 +35,6 @@
   "loadPreset": "読み込む",
   "deletePreset": "削除",
   "presetNamePlaceholder": "プリセット名を入力",
-  "noSavedPresets": "保存済みプリセットなし"
+  "noSavedPresets": "保存済みプリセットなし",
+  "monsterCount": "{{count}}体"
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -5,6 +5,7 @@ export type AttackType = "物理" | "魔法" | "魔弾";
 
 export interface MonsterBase {
   name: string;
+  nameEn?: string;
   level: number;
   element: Element;
   attackType: AttackType;


### PR DESCRIPTION
## Summary

- `docs/data/monsters.json` の全123エントリに `nameEn` フィールドを追加（`monster_name_mapping.json` より: 118件 stat_unique + 5件 manual_override）
- `MonsterBase` 型に `nameEn?: string` を追加（`types/game.ts`）
- `data/monsters.ts` に `getMonsterDisplayName(m, lang)` ヘルパーを追加
- `searchMonsters` を拡張: EN時に `nameEn` でも検索可能
- モンスター名表示箇所を `nameEn` 優先に更新:
  - `MonsterPickerModal`
  - `MonsterSelectorModal` (ui)
  - `ArenaCalculator` (`ArenaMonsterRow`)
  - `FarmCalculator`

## 確認事項

- [ ] `npx tsc --noEmit` → エラーなし ✅
- [ ] `npm run build` → 成功 ✅
- [ ] `monsters.json` の配列順序は変更なし（インデックス = 内部ID を維持） ✅
- [ ] EN切替時にモンスター名が英語表示される
- [ ] EN検索で英語名でも絞り込みできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)