### PR TITLE
feat(i18n): 装備・アクセサリ・ペット名の英語対応

### DIFF
--- a/docs/data/accessories.json
+++ b/docs/data/accessories.json
@@ -1,38 +1,494 @@
 [
-  { "name": "命脈の科学式",     "maxLevel": 100,  "effects": [{ "type": "VIT",   "value": 155, "scalePercent": 10 }] },
-  { "name": "鼓動核",           "maxLevel": 500,  "effects": [{ "type": "VIT%",  "value": 15,  "scalePercent": 1  }] },
-  { "name": "ウィンドクレスト", "maxLevel": 100,  "effects": [{ "type": "SPD",   "value": 135, "scalePercent": 10 }] },
-  { "name": "閃牙星",           "maxLevel": 500,  "effects": [{ "type": "SPD%",  "value": 15,  "scalePercent": 1  }] },
-  { "name": "ブラッドトニック", "maxLevel": 100,  "effects": [{ "type": "ATK",   "value": 90,  "scalePercent": 10 }, { "type": "ATK%", "value": 5, "scalePercent": 1 }] },
-  { "name": "力瓶",             "maxLevel": 500,  "effects": [{ "type": "ATK%",  "value": 20,  "scalePercent": 1  }] },
-  { "name": "アークグリモワール","maxLevel": 100,  "effects": [{ "type": "INT",   "value": 30,  "scalePercent": 10 }, { "type": "INT%", "value": 25, "scalePercent": 1 }] },
-  { "name": "創胎珠",           "maxLevel": 500,  "effects": [{ "type": "INT%",  "value": 20,  "scalePercent": 1  }] },
-  { "name": "フォースモジュール","maxLevel": 100,  "effects": [{ "type": "DEF",   "value": 80,  "scalePercent": 10 }, { "type": "M-DEF", "value": 90, "scalePercent": 10 }] },
-  { "name": "騎士の心得",       "maxLevel": 500,  "effects": [{ "type": "DEF%",  "value": 15,  "scalePercent": 1  }] },
-  { "name": "迷盾陣",           "maxLevel": 1000, "effects": [{ "type": "DEF%",  "value": 50,  "scalePercent": 1  }] },
-  { "name": "マギバインド",     "maxLevel": 100,  "effects": [{ "type": "M-DEF%","value": 25,  "scalePercent": 1  }] },
-  { "name": "結界嵐",           "maxLevel": 500,  "effects": [{ "type": "M-DEF%","value": 15,  "scalePercent": 1  }] },
-  { "name": "ヘキサスカル",     "maxLevel": 1000, "effects": [{ "type": "M-DEF%","value": 50,  "scalePercent": 1  }] },
-  { "name": "ラッキートランプ", "maxLevel": 100,  "effects": [{ "type": "LUCK",  "value": 99,  "scalePercent": 10 }, { "type": "LUCK%", "value": 15, "scalePercent": 1 }] },
-  { "name": "運命眼",           "maxLevel": 500,  "effects": [{ "type": "LUCK%", "value": 25,  "scalePercent": 1  }] },
-  { "name": "ギャロップタリスマン","maxLevel": 1, "effects": [{ "type": "MOV",   "value": 2,   "scalePercent": 0  }] },
-  { "name": "慈縛心",           "maxLevel": 1000, "effects": [{ "type": "HP回復","value": 100, "scalePercent": 20 }] },
-  { "name": "メモリアルページ", "maxLevel": 300,  "effects": [{ "type": "経験値","value": 30,  "scalePercent": 1  }] },
-  { "name": "賢者の盃",         "maxLevel": 300,  "effects": [{ "type": "経験値","value": 50,  "scalePercent": 1  }] },
-  { "name": "エクスペディアコンパス","maxLevel": 300, "effects": [{ "type": "経験値","value": 100,"scalePercent": 1 }] },
-  { "name": "知耀杯",           "maxLevel": 1000, "effects": [{ "type": "経験値","value": 180, "scalePercent": 1  }] },
-  { "name": "テイムマスク",     "maxLevel": 300,  "effects": [{ "type": "捕獲率","value": 30,  "scalePercent": 1  }] },
-  { "name": "魅誘盃",           "maxLevel": 300,  "effects": [{ "type": "捕獲率","value": 50,  "scalePercent": 1  }] },
-  { "name": "コンタクトレター", "maxLevel": 300,  "effects": [{ "type": "捕獲率","value": 80,  "scalePercent": 1  }] },
-  { "name": "拘魂鎖",           "maxLevel": 1000, "effects": [{ "type": "捕獲率","value": 100, "scalePercent": 1  }] },
-  { "name": "オービタルリング", "maxLevel": 300,  "effects": [{ "type": "ドロップ率","value": 30,"scalePercent": 1 }] },
-  { "name": "収索機",           "maxLevel": 1000, "effects": [{ "type": "ドロップ率","value": 50,"scalePercent": 1 }] },
-  { "name": "陽魂環",           "maxLevel": 1000, "effects": [{ "type": "VIT%",  "value": 30, "scalePercent": 1 }] },
-  { "name": "武器照合",         "maxLevel": 1000, "effects": [{ "type": "ATK%",  "value": 30, "scalePercent": 1 }] },
-  { "name": "マナランタン",     "maxLevel": 1000, "effects": [{ "type": "INT%",  "value": 30, "scalePercent": 1 }] },
-  { "name": "アークゲート",     "maxLevel": 10,   "effects": [{ "type": "経験値",    "value": 500, "scalePercent": 1 }, { "type": "ドロップ率", "value": 500, "scalePercent": 1 }] },
-  { "name": "ドミナススローン", "maxLevel": 10,   "effects": [{ "type": "経験値",    "value": 500, "scalePercent": 1 }, { "type": "捕獲率",    "value": 500, "scalePercent": 1 }] },
-  { "name": "フォーチュンポット","maxLevel": 10,   "effects": [{ "type": "ドロップ率","value": 1000, "scalePercent": 1 }] },
-  { "name": "ヴォルテクスコア", "maxLevel": 1,    "effects": [{ "type": "MOV",   "value": 3,   "scalePercent": 0  }] },
-  { "name": "七理の宝環",       "maxLevel": 100,  "effects": [{ "type": "VIT%",   "value": 50, "scalePercent": 1 }, { "type": "SPD%", "value": 50, "scalePercent": 1 }, { "type": "ATK%", "value": 50, "scalePercent": 1 }, { "type": "INT%", "value": 50, "scalePercent": 1 }, { "type": "DEF%", "value": 50, "scalePercent": 1 }, { "type": "M-DEF%", "value": 50, "scalePercent": 1 }, { "type": "LUCK%", "value": 50, "scalePercent": 1 }] }
+  {
+    "name": "命脈の科学式",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "VIT",
+        "value": 155,
+        "scalePercent": 10
+      }
+    ],
+    "nameEn": "Formula of Life Vein"
+  },
+  {
+    "name": "鼓動核",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "VIT%",
+        "value": 15,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Pulse Core"
+  },
+  {
+    "name": "ウィンドクレスト",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "SPD",
+        "value": 135,
+        "scalePercent": 10
+      }
+    ],
+    "nameEn": "Wind Crest"
+  },
+  {
+    "name": "閃牙星",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "SPD%",
+        "value": 15,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Fangflare"
+  },
+  {
+    "name": "ブラッドトニック",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "ATK",
+        "value": 90,
+        "scalePercent": 10
+      },
+      {
+        "type": "ATK%",
+        "value": 5,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Blood Tonic"
+  },
+  {
+    "name": "力瓶",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "ATK%",
+        "value": 20,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Power Bottle"
+  },
+  {
+    "name": "アークグリモワール",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "INT",
+        "value": 30,
+        "scalePercent": 10
+      },
+      {
+        "type": "INT%",
+        "value": 25,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Arc Grimoire"
+  },
+  {
+    "name": "創胎珠",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "INT%",
+        "value": 20,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Genesis Core"
+  },
+  {
+    "name": "フォースモジュール",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "DEF",
+        "value": 80,
+        "scalePercent": 10
+      },
+      {
+        "type": "M-DEF",
+        "value": 90,
+        "scalePercent": 10
+      }
+    ],
+    "nameEn": "Force Module"
+  },
+  {
+    "name": "騎士の心得",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "DEF%",
+        "value": 15,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Knight's Creed"
+  },
+  {
+    "name": "迷盾陣",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "DEF%",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Labyrinth Aegis"
+  },
+  {
+    "name": "マギバインド",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "M-DEF%",
+        "value": 25,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Magibind"
+  },
+  {
+    "name": "結界嵐",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "M-DEF%",
+        "value": 15,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Barrier Tempest"
+  },
+  {
+    "name": "ヘキサスカル",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "M-DEF%",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Hexa Skull"
+  },
+  {
+    "name": "ラッキートランプ",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "LUCK",
+        "value": 99,
+        "scalePercent": 10
+      },
+      {
+        "type": "LUCK%",
+        "value": 15,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Lucky Card"
+  },
+  {
+    "name": "運命眼",
+    "maxLevel": 500,
+    "effects": [
+      {
+        "type": "LUCK%",
+        "value": 25,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Fate Eye"
+  },
+  {
+    "name": "ギャロップタリスマン",
+    "maxLevel": 1,
+    "effects": [
+      {
+        "type": "MOV",
+        "value": 2,
+        "scalePercent": 0
+      }
+    ],
+    "nameEn": "Gallop Talisman"
+  },
+  {
+    "name": "慈縛心",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "HP回復",
+        "value": 100,
+        "scalePercent": 20
+      }
+    ],
+    "nameEn": "Bound Mercy"
+  },
+  {
+    "name": "メモリアルページ",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Memorial Page"
+  },
+  {
+    "name": "賢者の盃",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Sage's Chalice"
+  },
+  {
+    "name": "エクスペディアコンパス",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 100,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Expedia Compass"
+  },
+  {
+    "name": "知耀杯",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 180,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Cup of Enlightenment"
+  },
+  {
+    "name": "テイムマスク",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "捕獲率",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Tame Mask"
+  },
+  {
+    "name": "魅誘盃",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "捕獲率",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Allure Chalice"
+  },
+  {
+    "name": "コンタクトレター",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "捕獲率",
+        "value": 80,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Contact Letter"
+  },
+  {
+    "name": "拘魂鎖",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "捕獲率",
+        "value": 100,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Soulbind Chain"
+  },
+  {
+    "name": "オービタルリング",
+    "maxLevel": 300,
+    "effects": [
+      {
+        "type": "ドロップ率",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Orbital Ring"
+  },
+  {
+    "name": "収索機",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "ドロップ率",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Finder Array"
+  },
+  {
+    "name": "陽魂環",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "VIT%",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Solar Halo"
+  },
+  {
+    "name": "武器照合",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "ATK%",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Arsenal Sync"
+  },
+  {
+    "name": "マナランタン",
+    "maxLevel": 1000,
+    "effects": [
+      {
+        "type": "INT%",
+        "value": 30,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Mana Lantern"
+  },
+  {
+    "name": "アークゲート",
+    "maxLevel": 10,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 500,
+        "scalePercent": 1
+      },
+      {
+        "type": "ドロップ率",
+        "value": 500,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Arc Gate"
+  },
+  {
+    "name": "ドミナススローン",
+    "maxLevel": 10,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 500,
+        "scalePercent": 1
+      },
+      {
+        "type": "捕獲率",
+        "value": 500,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Dominus Throne"
+  },
+  {
+    "name": "フォーチュンポット",
+    "maxLevel": 10,
+    "effects": [
+      {
+        "type": "ドロップ率",
+        "value": 1000,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Fortune Pot"
+  },
+  {
+    "name": "ヴォルテクスコア",
+    "maxLevel": 1,
+    "effects": [
+      {
+        "type": "MOV",
+        "value": 3,
+        "scalePercent": 0
+      }
+    ],
+    "nameEn": "Vortex Core"
+  },
+  {
+    "name": "七理の宝環",
+    "maxLevel": 100,
+    "effects": [
+      {
+        "type": "VIT%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "SPD%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "ATK%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "INT%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "DEF%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "M-DEF%",
+        "value": 50,
+        "scalePercent": 1
+      },
+      {
+        "type": "LUCK%",
+        "value": 50,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": "Band of Seven Principles"
+  }
 ]

--- a/docs/data/equipment.json
+++ b/docs/data/equipment.json
@@ -13,7 +13,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 10
+    "order": 10,
+    "nameEn": "Bare Hands"
   },
   {
     "name": "銅のつるぎ",
@@ -29,7 +30,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 20
+    "order": 20,
+    "nameEn": "Copper Sword"
   },
   {
     "name": "鉄の剣",
@@ -45,7 +47,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 30
+    "order": 30,
+    "nameEn": "Iron Sword"
   },
   {
     "name": "エルフロッド",
@@ -61,7 +64,8 @@
     "luck": 12,
     "mov": 0,
     "special": null,
-    "order": 40
+    "order": 40,
+    "nameEn": "Elf Rod"
   },
   {
     "name": "ホーリースピア",
@@ -77,7 +81,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 50
+    "order": 50,
+    "nameEn": "Holy Spear"
   },
   {
     "name": "ダークスラッシャー",
@@ -93,7 +98,8 @@
     "luck": 0,
     "mov": 0,
     "special": "2体攻撃",
-    "order": 60
+    "order": 60,
+    "nameEn": "Dark Slasher"
   },
   {
     "name": "魔人の斧",
@@ -109,7 +115,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 70
+    "order": 70,
+    "nameEn": "Demon Axe"
   },
   {
     "name": "太陽の杖",
@@ -125,7 +132,8 @@
     "luck": 150,
     "mov": 0,
     "special": null,
-    "order": 80
+    "order": 80,
+    "nameEn": "Sun Staff"
   },
   {
     "name": "聖騎士ソード",
@@ -141,7 +149,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 90
+    "order": 90,
+    "nameEn": "Paladin Sword"
   },
   {
     "name": "雲神杖",
@@ -157,7 +166,8 @@
     "luck": 71,
     "mov": 1,
     "special": null,
-    "order": 100
+    "order": 100,
+    "nameEn": "Cloud God Staff"
   },
   {
     "name": "バーサクサーベル",
@@ -173,7 +183,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 110
+    "order": 110,
+    "nameEn": "Berserk Saber"
   },
   {
     "name": "星屑ブレード",
@@ -189,7 +200,8 @@
     "luck": 490,
     "mov": 0,
     "special": null,
-    "order": 120
+    "order": 120,
+    "nameEn": "Stardust Blade"
   },
   {
     "name": "悪夢の杖",
@@ -205,7 +217,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 130
+    "order": 130,
+    "nameEn": "Nightmare Staff"
   },
   {
     "name": "神速剣ギアセブン",
@@ -221,7 +234,8 @@
     "luck": 0,
     "mov": 3,
     "special": "3体攻撃",
-    "order": 140
+    "order": 140,
+    "nameEn": "Gear Seven"
   },
   {
     "name": "ちいさな剣",
@@ -237,7 +251,8 @@
     "luck": 5,
     "mov": 0,
     "special": null,
-    "order": 150
+    "order": 150,
+    "nameEn": "Small Sword"
   },
   {
     "name": "凍てついた杖",
@@ -253,7 +268,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 160
+    "order": 160,
+    "nameEn": "Frozen Staff"
   },
   {
     "name": "メタルハンマー",
@@ -269,7 +285,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 170
+    "order": 170,
+    "nameEn": "Metal Hammer"
   },
   {
     "name": "紅蓮槍",
@@ -285,7 +302,8 @@
     "luck": 110,
     "mov": 0,
     "special": null,
-    "order": 180
+    "order": 180,
+    "nameEn": "Scarlet Legion"
   },
   {
     "name": "アズールワンド",
@@ -301,7 +319,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 190
+    "order": 190,
+    "nameEn": "Azure Wand"
   },
   {
     "name": "マグマコア・ハンマー",
@@ -317,7 +336,8 @@
     "luck": 55,
     "mov": 0,
     "special": "3体攻撃",
-    "order": 200
+    "order": 200,
+    "nameEn": "Infernal Maul"
   },
   {
     "name": "如意棒",
@@ -333,7 +353,8 @@
     "luck": 219,
     "mov": 0,
     "special": null,
-    "order": 210
+    "order": 210,
+    "nameEn": "Ruyi Jingu Bang"
   },
   {
     "name": "邪悪杖マガツミ",
@@ -349,7 +370,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 220
+    "order": 220,
+    "nameEn": "Evil Staff Magatsumi"
   },
   {
     "name": "トライデント",
@@ -365,7 +387,8 @@
     "luck": 77777,
     "mov": 0,
     "special": "7体攻撃",
-    "order": 230
+    "order": 230,
+    "nameEn": "Trident"
   },
   {
     "name": "生贄100",
@@ -381,7 +404,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 240
+    "order": 240,
+    "nameEn": "Sacrifice 151"
   },
   {
     "name": "すごいおてて",
@@ -397,7 +421,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 250
+    "order": 250,
+    "nameEn": "Amazing Hands"
   },
   {
     "name": "なし",
@@ -413,7 +438,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 260
+    "order": 260,
+    "nameEn": "None"
   },
   {
     "name": "皮の帽子",
@@ -429,7 +455,8 @@
     "luck": 9,
     "mov": 0,
     "special": null,
-    "order": 270
+    "order": 270,
+    "nameEn": "Leather Cap"
   },
   {
     "name": "メタルヘルム",
@@ -445,7 +472,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 280
+    "order": 280,
+    "nameEn": "Metal Helm"
   },
   {
     "name": "白金ヘルム",
@@ -461,7 +489,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 290
+    "order": 290,
+    "nameEn": "Platinum Helm"
   },
   {
     "name": "魔導士フード",
@@ -477,7 +506,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 300
+    "order": 300,
+    "nameEn": "Mage Hood"
   },
   {
     "name": "獄炎兜",
@@ -493,7 +523,8 @@
     "luck": 100,
     "mov": 0,
     "special": null,
-    "order": 310
+    "order": 310,
+    "nameEn": "Infernal Helm"
   },
   {
     "name": "ドラゴンヘッド",
@@ -509,7 +540,8 @@
     "luck": 350,
     "mov": 0,
     "special": null,
-    "order": 320
+    "order": 320,
+    "nameEn": "Dragon Head"
   },
   {
     "name": "布の服",
@@ -525,7 +557,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 330
+    "order": 330,
+    "nameEn": "Cloth Clothes"
   },
   {
     "name": "皮の服",
@@ -541,7 +574,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 340
+    "order": 340,
+    "nameEn": "Leather Armor"
   },
   {
     "name": "鉄の鎧",
@@ -557,7 +591,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 350
+    "order": 350,
+    "nameEn": "Iron Armor"
   },
   {
     "name": "プラチナアーマー",
@@ -573,7 +608,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 360
+    "order": 360,
+    "nameEn": "Platinum Armor"
   },
   {
     "name": "魔導士のローブ",
@@ -589,7 +625,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 370
+    "order": 370,
+    "nameEn": "Mage Robe"
   },
   {
     "name": "獄炎の鎧",
@@ -605,7 +642,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 380
+    "order": 380,
+    "nameEn": "Infernal Armor"
   },
   {
     "name": "ドラゴンアーマー",
@@ -621,7 +659,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 390
+    "order": 390,
+    "nameEn": "Dragon Armor"
   },
   {
     "name": "なし",
@@ -637,7 +676,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 400
+    "order": 400,
+    "nameEn": "None"
   },
   {
     "name": "皮の盾",
@@ -653,7 +693,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 410
+    "order": 410,
+    "nameEn": "Leather Shield"
   },
   {
     "name": "鉄の盾",
@@ -669,7 +710,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 420
+    "order": 420,
+    "nameEn": "Iron Shield"
   },
   {
     "name": "プラチナの盾",
@@ -685,7 +727,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 430
+    "order": 430,
+    "nameEn": "Platinum Shield"
   },
   {
     "name": "魔導士の盾",
@@ -701,7 +744,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 440
+    "order": 440,
+    "nameEn": "Mage Shield"
   },
   {
     "name": "獄炎の盾",
@@ -717,7 +761,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 450
+    "order": 450,
+    "nameEn": "Infernal Shield"
   },
   {
     "name": "ドラゴンの盾",
@@ -733,7 +778,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 460
+    "order": 460,
+    "nameEn": "Dragon Shield"
   },
   {
     "name": "暴君盾",
@@ -749,7 +795,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 470
+    "order": 470,
+    "nameEn": "Violence Shield"
   },
   {
     "name": "なし",
@@ -765,7 +812,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 480
+    "order": 480,
+    "nameEn": "None"
   },
   {
     "name": "皮の手袋",
@@ -781,7 +829,8 @@
     "luck": 13,
     "mov": 0,
     "special": null,
-    "order": 490
+    "order": 490,
+    "nameEn": "Leather Gloves"
   },
   {
     "name": "鉄の小手",
@@ -797,7 +846,8 @@
     "luck": 23,
     "mov": 0,
     "special": null,
-    "order": 500
+    "order": 500,
+    "nameEn": "Iron Gauntlet"
   },
   {
     "name": "プラチナアーム",
@@ -813,7 +863,8 @@
     "luck": 125,
     "mov": 0,
     "special": null,
-    "order": 510
+    "order": 510,
+    "nameEn": "Platinum Arm"
   },
   {
     "name": "魔導士のガントレット",
@@ -829,7 +880,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 520
+    "order": 520,
+    "nameEn": "Mage Gauntlet"
   },
   {
     "name": "獄炎アーム",
@@ -845,7 +897,8 @@
     "luck": 130,
     "mov": 0,
     "special": null,
-    "order": 530
+    "order": 530,
+    "nameEn": "Infernal Arm"
   },
   {
     "name": "ドラゴンブレイサー",
@@ -861,7 +914,8 @@
     "luck": 350,
     "mov": 0,
     "special": null,
-    "order": 540
+    "order": 540,
+    "nameEn": "Dragon Bracer"
   },
   {
     "name": "ただのくつ",
@@ -877,7 +931,8 @@
     "luck": 0,
     "mov": 4,
     "special": null,
-    "order": 550
+    "order": 550,
+    "nameEn": "Plain Shoes"
   },
   {
     "name": "皮のシューズ",
@@ -893,7 +948,8 @@
     "luck": 0,
     "mov": 5,
     "special": null,
-    "order": 560
+    "order": 560,
+    "nameEn": "Leather Shoes"
   },
   {
     "name": "鉄のブーツ",
@@ -909,7 +965,8 @@
     "luck": 11,
     "mov": 3,
     "special": null,
-    "order": 570
+    "order": 570,
+    "nameEn": "Iron Boots"
   },
   {
     "name": "プラチナブーツ",
@@ -925,7 +982,8 @@
     "luck": 0,
     "mov": 6,
     "special": null,
-    "order": 580
+    "order": 580,
+    "nameEn": "Platinum Boots"
   },
   {
     "name": "魔導士の靴",
@@ -941,7 +999,8 @@
     "luck": 0,
     "mov": 5,
     "special": null,
-    "order": 590
+    "order": 590,
+    "nameEn": "Mage Shoes"
   },
   {
     "name": "獄炎ブーツ",
@@ -957,7 +1016,8 @@
     "luck": 0,
     "mov": 5,
     "special": null,
-    "order": 600
+    "order": 600,
+    "nameEn": "Infernal Boots"
   },
   {
     "name": "ドラゴンレッグ",
@@ -973,7 +1033,8 @@
     "luck": 0,
     "mov": 6,
     "special": null,
-    "order": 610
+    "order": 610,
+    "nameEn": "Dragon Leg"
   },
   {
     "name": "暴君ヘルム",
@@ -989,7 +1050,8 @@
     "luck": 1200,
     "mov": 0,
     "special": null,
-    "order": 620
+    "order": 620,
+    "nameEn": "Violence Helm"
   },
   {
     "name": "暴君ジャケット",
@@ -1005,7 +1067,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 630
+    "order": 630,
+    "nameEn": "Violence Jacket"
   },
   {
     "name": "暴君アーム",
@@ -1021,7 +1084,8 @@
     "luck": 400,
     "mov": 0,
     "special": null,
-    "order": 640
+    "order": 640,
+    "nameEn": "Violence Arm"
   },
   {
     "name": "暴君シューズ",
@@ -1037,7 +1101,8 @@
     "luck": 0,
     "mov": 4,
     "special": null,
-    "order": 650
+    "order": 650,
+    "nameEn": "Violence Shoes"
   },
   {
     "name": "オーディンアックス",
@@ -1053,7 +1118,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 145
+    "order": 145,
+    "nameEn": "Odin Axe"
   },
   {
     "name": "魔剣タルタロス",
@@ -1069,7 +1135,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 660
+    "order": 660,
+    "nameEn": "Demonic Sword Tartarus"
   },
   {
     "name": "絶聖剣ニケ",
@@ -1085,7 +1152,8 @@
     "luck": 0,
     "mov": 1,
     "special": null,
-    "order": 670
+    "order": 670,
+    "nameEn": "Holy Spear Nike"
   },
   {
     "name": "悪魔ヘルム",
@@ -1101,7 +1169,8 @@
     "luck": 555,
     "mov": 0,
     "special": null,
-    "order": 680
+    "order": 680,
+    "nameEn": "Demon Helm"
   },
   {
     "name": "悪魔の鎧",
@@ -1117,7 +1186,8 @@
     "luck": 955,
     "mov": 0,
     "special": null,
-    "order": 690
+    "order": 690,
+    "nameEn": "Demon Armor"
   },
   {
     "name": "悪魔の盾",
@@ -1133,7 +1203,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 700
+    "order": 700,
+    "nameEn": "Demon Shield"
   },
   {
     "name": "悪魔の小手",
@@ -1149,7 +1220,8 @@
     "luck": 4655,
     "mov": 0,
     "special": null,
-    "order": 710
+    "order": 710,
+    "nameEn": "Demon Gauntlet"
   },
   {
     "name": "悪魔の靴",
@@ -1165,7 +1237,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 720
+    "order": 720,
+    "nameEn": "Demon Shoes"
   },
   {
     "name": "持つ書物",
@@ -1181,7 +1254,8 @@
     "luck": 0,
     "mov": 0,
     "special": null,
-    "order": 730
+    "order": 730,
+    "nameEn": "Tome Weapon"
   },
   {
     "name": "ネギソード",
@@ -1197,7 +1271,8 @@
     "luck": 0,
     "mov": 5,
     "special": null,
-    "order": 740
+    "order": 740,
+    "nameEn": "Green Onion Sword"
   },
   {
     "name": "ワタッガシ",
@@ -1213,7 +1288,8 @@
     "luck": 3999,
     "mov": 0,
     "special": "5体攻撃\n攻撃範囲増（小）",
-    "order": 750
+    "order": 750,
+    "nameEn": "Cotton Candy Stick"
   },
   {
     "name": "滅界双刃",
@@ -1229,6 +1305,7 @@
     "luck": 0,
     "mov": 2,
     "special": "2体攻撃\n攻撃範囲増（中）",
-    "order": 760
+    "order": 760,
+    "nameEn": "Twin Blades of Ruin"
   }
 ]

--- a/src/components/SimConfigPanel.tsx
+++ b/src/components/SimConfigPanel.tsx
@@ -6,7 +6,7 @@ import {
   getEquipmentByName, equipment,
   getAccessoryByName, accessories,
   getPetsByPrimaryStat, getPetSkillSummaryForCategory,
-  getPatternLevels, getPetMaxLevel,
+  getPatternLevels, getPetMaxLevel, getPetNameEn,
 } from "../data";
 import type { PetStatCategory, PetCategoryGroup } from "../data";
 import type { SimConfig, CoreStats, EquipmentSlot, Element, AccessoryItem, EquipmentItem } from "../types/game";
@@ -312,7 +312,8 @@ function EquipSelectorModal({
   onEquipChange: (name: string) => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
@@ -379,7 +380,7 @@ function EquipSelectorModal({
                         }`}
                       >
                         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${selected ? "bg-blue-400" : "bg-gray-300"}`} />
-                        <span className="flex-1 text-left text-xs truncate">{item.name}</span>
+                        <span className="flex-1 text-left text-xs truncate">{isEn ? (item.nameEn ?? item.name) : item.name}</span>
                         {summary && <span className="text-xs text-gray-400 shrink-0">{summary}</span>}
                       </button>
                     );
@@ -414,7 +415,8 @@ function EquipSelector({
   onEquipChange: (name: string) => void;
   onEnhChange: (v: number) => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
   const [modalOpen, setModalOpen] = useState(false);
   const item = selectedName ? getEquipmentByName(selectedName) : undefined;
   const canEnhance = item ? item.material !== "強化できない" : false;
@@ -430,7 +432,7 @@ function EquipSelector({
           className="flex-1 text-left border border-gray-200 rounded-lg px-3 py-1.5 text-xs bg-white hover:bg-gray-50 transition-colors min-w-0"
         >
           {!isNone
-            ? <span className="text-gray-700 truncate block">{selectedName}</span>
+            ? <span className="text-gray-700 truncate block">{isEn ? (item?.nameEn ?? selectedName) : selectedName}</span>
             : <span className="text-gray-400">{t("common:noneTapToSelect")}</span>
           }
         </button>
@@ -467,7 +469,8 @@ function AccSelectorModal({
   onAccChange: (name: string) => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
   const [openCategory, setOpenCategory] = useState<AccCategory | null>(null);
 
   useEffect(() => {
@@ -545,7 +548,7 @@ function AccSelectorModal({
                           }`}
                         >
                           <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${selected ? "bg-blue-400" : "bg-gray-300"}`} />
-                          <span className="flex-1 text-left text-xs truncate">{acc.name}</span>
+                          <span className="flex-1 text-left text-xs truncate">{isEn ? (acc.nameEn ?? acc.name) : acc.name}</span>
                           <span className="text-xs text-gray-400 shrink-0">{getAccSummary(acc)}</span>
                           <span className="text-xs text-gray-300 shrink-0">{getAccMaxLvLabel(acc.maxLevel, t)}</span>
                         </button>
@@ -583,7 +586,9 @@ function AccSelector({
   onAccChange: (name: string) => void;
   onLevelChange: (lv: number) => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
+  const accItem = accName ? getAccessoryByName(accName) : undefined;
   const [modalOpen, setModalOpen] = useState(false);
   return (
     <div className="space-y-1.5">
@@ -595,7 +600,7 @@ function AccSelector({
           className="flex-1 text-left border border-gray-200 rounded-lg px-3 py-1.5 text-xs bg-white hover:bg-gray-50 transition-colors min-w-0"
         >
           {accName
-            ? <span className="text-gray-700 truncate block">{accName}</span>
+            ? <span className="text-gray-700 truncate block">{isEn ? (accItem?.nameEn ?? accName) : accName}</span>
             : <span className="text-gray-400">{t("common:noneTapToSelect")}</span>
           }
         </button>
@@ -652,7 +657,8 @@ function PetSubGroup({
   onPetChange: (name: string) => void;
   onLevelChange: (level: number) => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
   if (pets.length === 0) return null;
   const labelCls = SUBGROUP_STYLE[label] ?? "bg-gray-50 text-gray-500 border-gray-200";
   const translatedLabel = SUBGROUP_LABEL_KEY[label] ? t(SUBGROUP_LABEL_KEY[label]) : label;
@@ -683,7 +689,7 @@ function PetSubGroup({
               }`}
             >
               <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${selected ? "bg-blue-400" : "bg-gray-300"}`} />
-              <span className="flex-1 text-left text-xs truncate">{pet.name}</span>
+              <span className="flex-1 text-left text-xs truncate">{isEn ? (getPetNameEn(pet.name) ?? pet.name) : pet.name}</span>
               {pet.pattern === 2 && (
                 <span className="text-xs text-purple-500 font-bold shrink-0 mr-1">P2</span>
               )}
@@ -846,8 +852,10 @@ function PetSelector({
   onPetChange: (name: string) => void;
   onLevelChange: (level: number) => void;
 }) {
-  const { t } = useTranslation("status");
+  const { t, i18n } = useTranslation("status");
+  const isEn = i18n.language === "en";
   const [modalOpen, setModalOpen] = useState(false);
+  const petDisplayName = petName ? (isEn ? (getPetNameEn(petName) ?? petName) : petName) : "";
 
   return (
     <div className="space-y-1">
@@ -858,7 +866,7 @@ function PetSelector({
         className="w-full text-left border border-gray-200 rounded-lg px-3 py-1.5 text-xs bg-white hover:bg-gray-50 transition-colors"
       >
         {petName
-          ? <span className="text-gray-700">{petName}（{petLevel === 0 ? "Lv—" : `Lv${petLevel}`}）</span>
+          ? <span className="text-gray-700">{petDisplayName}（{petLevel === 0 ? "Lv—" : `Lv${petLevel}`}）</span>
           : <span className="text-gray-400">{t("common:noneTapToSelect")}</span>
         }
       </button>

--- a/src/components/ui/EquipmentSummaryModal.tsx
+++ b/src/components/ui/EquipmentSummaryModal.tsx
@@ -4,6 +4,8 @@ import { useSharedSimConfig } from "../../hooks/useSharedSimConfig";
 import { usePersistedState } from "../../hooks/usePersistedState";
 import { calcStatus } from "../../utils/statusCalc";
 import { getEquipmentByName } from "../../data/equipment";
+import { getAccessoryByName } from "../../data/accessories";
+import { getPetNameEn } from "../../data/petSkills";
 
 const STAT_LABELS: Record<string, string> = {
   vit: "VIT", spd: "SPD", atk: "ATK", int: "INT",
@@ -46,7 +48,9 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 }
 
 export function EquipmentSummaryModal({ onClose }: { onClose: () => void }) {
-  const { t } = useTranslation(["common", "status", "game"]);
+  const { t, i18n } = useTranslation(["common", "status", "game"]);
+  const isEn = i18n.language === "en";
+  const displayName = (jaName: string, nameEn?: string) => (isEn ? (nameEn ?? jaName) : jaName);
   const [cfg] = useSharedSimConfig();
   const [copied, setCopied] = useState(false);
   const [crystalCubeRaw] = usePersistedState("dmg:crystalCube", "");
@@ -227,12 +231,12 @@ export function EquipmentSummaryModal({ onClose }: { onClose: () => void }) {
           <div>
             <SectionHeader>{t("status:equipment")}</SectionHeader>
             <div className="space-y-1 max-w-[60%]">
-              <ItemRow label={slotLabel("武器")} name={cfg.equipWeapon} enh={cfg.enhWeapon} canEnhance={weaponCanEnh} />
+              <ItemRow label={slotLabel("武器")} name={displayName(cfg.equipWeapon, weaponItem?.nameEn)} enh={cfg.enhWeapon} canEnhance={weaponCanEnh} />
               {armorSlots.map(({ slot, name, enh, item }) => (
                 <ItemRow
                   key={slot}
                   label={slotLabel(slot)}
-                  name={name}
+                  name={displayName(name, item?.nameEn)}
                   enh={enh}
                   canEnhance={item ? item.material !== "強化できない" : true}
                 />
@@ -253,7 +257,7 @@ export function EquipmentSummaryModal({ onClose }: { onClose: () => void }) {
                   <span className="text-gray-400 w-8 shrink-0">{i + 1}</span>
                   {s.name
                     ? <>
-                        <span className="text-gray-800 font-medium flex-1 min-w-0 truncate">{s.name}</span>
+                        <span className="text-gray-800 font-medium flex-1 min-w-0 truncate">{displayName(s.name, getAccessoryByName(s.name)?.nameEn)}</span>
                         <span className="text-gray-400 shrink-0">Lv.{s.level}</span>
                       </>
                     : <span className="text-gray-300 flex-1">-</span>
@@ -271,7 +275,7 @@ export function EquipmentSummaryModal({ onClose }: { onClose: () => void }) {
                   <span className="text-gray-400 w-8 shrink-0">{i + 1}</span>
                   {s.name
                     ? <>
-                        <span className="text-gray-800 font-medium flex-1 min-w-0 truncate">{s.name}</span>
+                        <span className="text-gray-800 font-medium flex-1 min-w-0 truncate">{displayName(s.name, getPetNameEn(s.name))}</span>
                         <span className="text-gray-400 shrink-0">Lv.{s.level}</span>
                       </>
                     : <span className="text-gray-300 flex-1">-</span>

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,4 @@
 export { getEquipmentBySlot, getEquipmentByName, equipment } from "./equipment";
 export { getAccessoryByName, getAllAccessoryNames, calcAccEffectAtLevel, accessories } from "./accessories";
-export { getPetByName, getActiveSkills, getAllPetNames, getPetsByElement, getPetsByPrimaryStat, getPetMaxSkillSummary, getPetSkillSummaryForCategory, getPatternLevels, getPetMaxLevel, pets } from "./petSkills";
+export { getPetByName, getActiveSkills, getAllPetNames, getPetsByElement, getPetsByPrimaryStat, getPetMaxSkillSummary, getPetSkillSummaryForCategory, getPatternLevels, getPetMaxLevel, getPetNameEn, pets } from "./petSkills";
 export type { PetStatCategory, PetCategoryGroup } from "./petSkills";

--- a/src/data/petSkills.ts
+++ b/src/data/petSkills.ts
@@ -27,8 +27,19 @@ const monsterElements = new Map<string, Element>(
   )
 );
 
+// Build English name lookup from monsters data
+const monsterNamesEn = new Map<string, string>(
+  (monstersJson as Array<{ name: string; nameEn?: string }>)
+    .filter((m) => m.nameEn)
+    .map((m) => [m.name, m.nameEn!])
+);
+
 export function getPetElement(petName: string): Element | null {
   return monsterElements.get(petName) ?? null;
+}
+
+export function getPetNameEn(petName: string): string | undefined {
+  return monsterNamesEn.get(petName);
 }
 
 /** ペットを属性別にグループ化して返す */

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -40,6 +40,7 @@ export type EquipmentSlot = "武器" | "頭" | "服" | "手" | "盾" | "脚";
 
 export interface EquipmentItem {
   name: string;
+  nameEn?: string;
   slot: EquipmentSlot;
   series?: string | null;
   material?: string;
@@ -66,6 +67,7 @@ export interface AccessoryEffect {
 
 export interface AccessoryItem {
   name: string;
+  nameEn?: string;
   maxLevel: number;
   effects: AccessoryEffect[];
 }


### PR DESCRIPTION
## 変更内容

OnceWorld wiki から取得した公式英語名を装備・アクセサリ・ペットデータに追加し、EN モード時に表示を切り替えるようにした。

### データ
- `docs/data/equipment.json` — 77件に `nameEn` 追加（公式wiki名）
- `docs/data/accessories.json` — 36件に `nameEn` 追加（公式wiki名）
- 配列順序・既存エントリは一切変更なし（URL共有互換維持）

### 型・ロジック
- `types/game.ts`: `EquipmentItem` / `AccessoryItem` に `nameEn?: string` 追加
- `src/data/petSkills.ts`: `getPetNameEn()` 追加（monsters.json の nameEn を参照）
- `src/data/index.ts`: `getPetNameEn` をエクスポート

### 表示
- `SimConfigPanel`: 装備/アクセサリ/ペット 選択モーダルとボタン表示で EN 対応
- `EquipmentSummaryModal`: 装備サマリーモーダルで EN 対応

### wikiで確認した主な英語名の修正点（agent推測との差異）
| JP | 修正前推測 | wiki正式名 |
|----|-----------|-----------|
| 聖騎士ソード | Holy Knight Sword | Paladin Sword |
| 暴君系 | Tyrant | Violence |
| 紅蓮槍 | Crimson Lance | Scarlet Legion |
| マグマコア・ハンマー | Magma Core Hammer | Infernal Maul |
| ラッキートランプ | Lucky Trance | Lucky Card |
| 陽魂環 | Solar Soul Ring | Solar Halo |
| 迷盾陣 | Maze Shield Array | Labyrinth Aegis |

## 確認事項
- [ ] `npx tsc --noEmit` 通過 ✅
- [ ] `npm run build` 成功 ✅
- [ ] ブラウザで JA→EN→JA 切替して装備名・アクセサリ名・ペット名が切り替わること
- [ ] 既存共有URLが引き続き動作すること（nameEn は表示のみ、内部値は JP 維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)