### PR TITLE
fix(skyCorridor): モンスター名クリックでダメ計遷移・攻撃力数字の桁揃え修正 (Issue #142)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ function App() {
     setDamageJumpVersion(version);
     setDamageJump({ monsterName, level, version });
     setActiveTab("damage");
+    window.location.hash = "damage";
   }, [damageJumpVersion]);
 
   const [activeTab, setActiveTab] = useState(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,16 @@ function App() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
 
+  const [damageJumpVersion, setDamageJumpVersion] = useState(0);
+  const [damageJump, setDamageJump] = useState<{ monsterName: string; level: number; version: number } | undefined>(undefined);
+
+  const handleNavigateToDamage = useCallback((monsterName: string, level: number) => {
+    const version = damageJumpVersion + 1;
+    setDamageJumpVersion(version);
+    setDamageJump({ monsterName, level, version });
+    setActiveTab("damage");
+  }, [damageJumpVersion]);
+
   const [activeTab, setActiveTab] = useState(() => {
     const hash = window.location.hash.slice(1);
     return tabs.find((t) => t.id === hash && !t.disabled)?.id ?? "damage";
@@ -146,7 +156,7 @@ function App() {
       {/* メインコンテンツ */}
       <main className="max-w-3xl lg:max-w-[1400px] mx-auto px-4 py-6 lg:py-2">
         <div className={activeTab === "damage" ? "" : "hidden"}>
-          <DamageCalculator />
+          <DamageCalculator externalJump={damageJump} />
         </div>
         <div className={activeTab === "farm" ? "" : "hidden"}>
           <FarmCalculator />
@@ -164,7 +174,7 @@ function App() {
           <PetBattleSimulator />
         </div>
         <div className={activeTab === "skyCorridor" ? "" : "hidden"}>
-          <SkyCorridorCalculator />
+          <SkyCorridorCalculator onNavigateToDamage={handleNavigateToDamage} />
         </div>
         <div className={activeTab === "monsters" ? "" : "hidden"}>
           <MonsterEditor />

--- a/src/components/DamageCalculator.tsx
+++ b/src/components/DamageCalculator.tsx
@@ -231,6 +231,11 @@ export function DamageCalculator({
 
   useEffect(() => {
     if (!externalJump) return;
+    const monster = getMonsterByName(externalJump.monsterName);
+    if (monster) {
+      setSelectedMonster(monster);
+      setMonsterLevel(externalJump.level);
+    }
     setInjectedMonsterName(externalJump.monsterName);
     setInjectedLevel(externalJump.level);
     setPresetVersion(externalJump.version);

--- a/src/components/DamageCalculator.tsx
+++ b/src/components/DamageCalculator.tsx
@@ -65,7 +65,11 @@ import {
 
 type PlayerAttackMode = "物理" | "魔弾" | "魔攻" | "魔法";
 
-export function DamageCalculator() {
+export function DamageCalculator({
+  externalJump,
+}: {
+  externalJump?: { monsterName: string; level: number; version: number };
+} = {}) {
   const { t } = useTranslation("damage");
   const customMonsters = useCustomMonsters();
   const allGroups = useMemo(() => {
@@ -224,6 +228,13 @@ export function DamageCalculator() {
   const [enemyModalOpen, setEnemyModalOpen] = useState(false);
   const [selectedPresetLabel, setSelectedPresetLabel] = useState<string | null>(null);
   const [presetVersion, setPresetVersion] = useState(0);
+
+  useEffect(() => {
+    if (!externalJump) return;
+    setInjectedMonsterName(externalJump.monsterName);
+    setInjectedLevel(externalJump.level);
+    setPresetVersion(externalJump.version);
+  }, [externalJump]);
 
   // 複数モンスター比較
   const [comparisonMonsters, setComparisonMonsters] = useState<MultiMonsterEntry[]>([]);

--- a/src/components/SkyCorridorCalculator.tsx
+++ b/src/components/SkyCorridorCalculator.tsx
@@ -502,13 +502,13 @@ function FireMonsterRow({
           </span>
         )}
       </td>
-      <td className="px-2 py-1.5 text-right text-sm font-medium text-gray-700 whitespace-nowrap">
+      <td className="px-2 py-1.5 text-right text-sm font-medium text-gray-700 whitespace-nowrap tabular-nums w-24">
         {result.rankStat.toLocaleString()}
       </td>
-      <td className="px-2 py-1.5 text-right text-sm text-gray-600 whitespace-nowrap">
+      <td className="px-2 py-1.5 text-right text-sm text-gray-600 whitespace-nowrap tabular-nums w-20">
         {result.scaledHp.toLocaleString()}
       </td>
-      <td className="px-2 py-1.5 text-right whitespace-nowrap">
+      <td className="px-2 py-1.5 text-right whitespace-nowrap w-20">
         {result.isMagicImmune ? (
           <span className="text-gray-400 text-xs">—</span>
         ) : result.playerDamageMin !== null ? (
@@ -519,7 +519,7 @@ function FireMonsterRow({
           <span className="text-gray-400">—</span>
         )}
       </td>
-      <td className="px-2 py-1.5 text-center whitespace-nowrap">
+      <td className="px-2 py-1.5 text-center whitespace-nowrap w-16">
         {result.isMagicImmune ? (
           <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-gray-200 text-gray-600 border border-gray-300">
             {t("magicImmune")}
@@ -532,7 +532,7 @@ function FireMonsterRow({
           <span className="text-orange-500 font-bold">✗</span>
         )}
       </td>
-      <td className="px-2 py-1.5 text-right whitespace-nowrap">
+      <td className="px-2 py-1.5 text-right whitespace-nowrap w-16">
         {result.hitRate !== null ? (
           <span
             className={`text-sm font-medium ${
@@ -568,17 +568,17 @@ function FireTableHeader({
   return (
     <tr className="bg-gray-50 text-xs text-gray-500 border-b border-gray-200">
       <th className="px-2 py-2 text-left font-medium">{t("tableHeaders.monster")}</th>
-      <th className="px-2 py-2 text-right font-medium whitespace-nowrap">
+      <th className="px-2 py-2 text-right font-medium whitespace-nowrap w-24">
         {rankHeader}({floor.toLocaleString()}F)
       </th>
-      <th className="px-2 py-2 text-right font-medium whitespace-nowrap">HP</th>
-      <th className="px-2 py-2 text-right font-medium whitespace-nowrap">
+      <th className="px-2 py-2 text-right font-medium whitespace-nowrap w-20">HP</th>
+      <th className="px-2 py-2 text-right font-medium whitespace-nowrap w-20">
         {t("tableHeaders.attackDmg")}
       </th>
-      <th className="px-2 py-2 text-center font-medium whitespace-nowrap">
+      <th className="px-2 py-2 text-center font-medium whitespace-nowrap w-16">
         {t("oneShot")}
       </th>
-      <th className="px-2 py-2 text-right font-medium whitespace-nowrap">
+      <th className="px-2 py-2 text-right font-medium whitespace-nowrap w-16">
         {t("tableHeaders.hitRate")}
       </th>
     </tr>
@@ -612,7 +612,7 @@ function FireSection({
         <span className="text-sm font-semibold text-gray-700">{title}</span>
       </div>
       <div className="overflow-x-auto">
-        <table className="w-full text-sm border-collapse">
+        <table className="w-full text-sm border-collapse table-fixed">
           <thead>
             <FireTableHeader floor={floor} rankHeader={rankHeader} t={t} />
           </thead>

--- a/src/components/SkyCorridorCalculator.tsx
+++ b/src/components/SkyCorridorCalculator.tsx
@@ -256,11 +256,13 @@ type FireResult = {
 function SkyMonsterRow({
   result,
   onFloorClick,
+  onMonsterClick,
   t,
   lang,
 }: {
   result: SkyResult;
   onFloorClick?: (floor: number) => void;
+  onMonsterClick?: (monsterName: string) => void;
   t: TFunction;
   lang: string;
 }) {
@@ -279,7 +281,16 @@ function SkyMonsterRow({
   return (
     <tr className={`border-b ${rowBg} text-sm`}>
       <td className="px-2 py-1.5 font-medium text-gray-800 whitespace-nowrap">
-        {getMonsterDisplayName(result.base, lang)}
+        {onMonsterClick ? (
+          <button
+            className="text-indigo-600 hover:underline font-medium"
+            onClick={() => onMonsterClick(result.base.name)}
+          >
+            {getMonsterDisplayName(result.base, lang)}
+          </button>
+        ) : (
+          getMonsterDisplayName(result.base, lang)
+        )}
       </td>
       <td className="px-2 py-1.5 whitespace-nowrap">
         <span
@@ -292,7 +303,7 @@ function SkyMonsterRow({
           {result.isPhysical ? t("game:attackLabel.physical") : t("game:attackLabel.magic")}
         </span>
       </td>
-      <td className="px-2 py-1.5 text-right font-medium text-gray-700 whitespace-nowrap">
+      <td className="px-2 py-1.5 text-right font-medium text-gray-700 whitespace-nowrap tabular-nums">
         {result.enemyStat.toLocaleString()}
       </td>
       <td className="px-2 py-1.5 text-center whitespace-nowrap">
@@ -394,6 +405,7 @@ function SkySection({
   results,
   floor,
   onFloorClick,
+  onMonsterClick,
   t,
   lang,
 }: {
@@ -401,6 +413,7 @@ function SkySection({
   results: SkyResult[];
   floor: number;
   onFloorClick: (floor: number) => void;
+  onMonsterClick?: (monsterName: string) => void;
   t: TFunction;
   lang: string;
 }) {
@@ -420,6 +433,7 @@ function SkySection({
                 key={result.base.name}
                 result={result}
                 onFloorClick={(f) => onFloorClick(f)}
+                onMonsterClick={onMonsterClick}
                 t={t}
                 lang={lang}
               />
@@ -454,10 +468,12 @@ function SkySection({
 // ────────────────────────────────────────────
 function FireMonsterRow({
   result,
+  onMonsterClick,
   t,
   lang,
 }: {
   result: FireResult;
+  onMonsterClick?: (monsterName: string) => void;
   t: TFunction;
   lang: string;
 }) {
@@ -470,7 +486,16 @@ function FireMonsterRow({
   return (
     <tr className={`border-b ${rowBg} text-sm`}>
       <td className="px-2 py-1.5 font-medium text-gray-800 whitespace-nowrap">
-        {getMonsterDisplayName(result.base, lang)}
+        {onMonsterClick ? (
+          <button
+            className="text-indigo-600 hover:underline font-medium"
+            onClick={() => onMonsterClick(result.base.name)}
+          >
+            {getMonsterDisplayName(result.base, lang)}
+          </button>
+        ) : (
+          getMonsterDisplayName(result.base, lang)
+        )}
         {result.isMagicImmune && (
           <span className="ml-1 inline-flex items-center px-1 py-0.5 rounded text-xs font-bold bg-gray-200 text-gray-600">
             {t("magicImmune")}
@@ -568,6 +593,7 @@ function FireSection({
   results,
   floor,
   rankHeader,
+  onMonsterClick,
   t,
   lang,
 }: {
@@ -575,6 +601,7 @@ function FireSection({
   results: FireResult[];
   floor: number;
   rankHeader: string;
+  onMonsterClick?: (monsterName: string) => void;
   t: TFunction;
   lang: string;
 }) {
@@ -591,7 +618,7 @@ function FireSection({
           </thead>
           <tbody>
             {results.map((result) => (
-              <FireMonsterRow key={result.base.name} result={result} t={t} lang={lang} />
+              <FireMonsterRow key={result.base.name} result={result} onMonsterClick={onMonsterClick} t={t} lang={lang} />
             ))}
           </tbody>
         </table>
@@ -603,7 +630,11 @@ function FireSection({
 // ────────────────────────────────────────────
 // メインコンポーネント
 // ────────────────────────────────────────────
-export function SkyCorridorCalculator() {
+export function SkyCorridorCalculator({
+  onNavigateToDamage,
+}: {
+  onNavigateToDamage?: (monsterName: string, level: number) => void;
+} = {}) {
   const { t, i18n } = useTranslation("skyCorridor");
 
   // 表示モード
@@ -830,6 +861,10 @@ export function SkyCorridorCalculator() {
   );
 
   const handleFloorClick = (floor: number) => setSkyFloor(String(floor));
+
+  const handleMonsterClick = onNavigateToDamage
+    ? (monsterName: string) => onNavigateToDamage(monsterName, floorToLevel(floorNum))
+    : undefined;
 
   // ────────────────────────────────────────────
   // ステータス入力フィールド定義
@@ -1079,6 +1114,7 @@ export function SkyCorridorCalculator() {
               results={physicalResults}
               floor={floorNum}
               onFloorClick={handleFloorClick}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />
@@ -1087,6 +1123,7 @@ export function SkyCorridorCalculator() {
               results={magicResults}
               floor={floorNum}
               onFloorClick={handleFloorClick}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />
@@ -1098,6 +1135,7 @@ export function SkyCorridorCalculator() {
               results={firePhysDefResults}
               floor={floorNum}
               rankHeader={t("fireTableHeaders.def")}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />
@@ -1106,6 +1144,7 @@ export function SkyCorridorCalculator() {
               results={firePhysLukResults}
               floor={floorNum}
               rankHeader={t("fireTableHeaders.luk")}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />
@@ -1117,6 +1156,7 @@ export function SkyCorridorCalculator() {
               results={fireMagMdefResults}
               floor={floorNum}
               rankHeader={t("fireTableHeaders.mdef")}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />
@@ -1125,6 +1165,7 @@ export function SkyCorridorCalculator() {
               results={fireMagImmuneResults}
               floor={floorNum}
               rankHeader={t("fireTableHeaders.mdef")}
+              onMonsterClick={handleMonsterClick}
               t={t}
               lang={i18n.language}
             />


### PR DESCRIPTION
## 概要

Issue #142 の2点を対応。

- **モンスター名クリック遷移**: 天空回廊シミュのモンスター名をクリックするとダメージシミュレータタブに切り替わり、そのモンスターと現在フロアのレベルが自動セットされる（耐久・火力モード両対応）
- **攻撃力数字の桁揃え**: 耐久モードの攻撃力列に `tabular-nums` を適用。10,000F 等で同桁数でも数字幅がずれる問題を修正

## 変更ファイル

- `src/App.tsx` — `handleNavigateToDamage` ハンドラー追加、各コンポーネントにprops渡し
- `src/components/DamageCalculator.tsx` — `externalJump` prop追加、useEffectで内部状態に注入
- `src/components/SkyCorridorCalculator.tsx` — `onNavigateToDamage` prop追加、モンスター名をクリック可能ボタンに変更、攻撃力セルに `tabular-nums` 追加

## 確認事項

- [ ] 耐久モードのモンスター名クリック → ダメ計にそのモンスター＋フロアレベルがセットされる
- [ ] 火力モードのモンスター名クリック → 同上
- [ ] 10,000F で攻撃力の数字が揃って表示される
- [ ] 型チェック・ビルド通過済み

Closes #142