### PR TITLE
feat(enemyPresets): 深淵回廊26Fのモンスタープリセットを追加

### DIFF
--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -187,6 +187,17 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
       { monsterName: "冥炎のハデス",       level: 250000, location: "25層",              locationEn: "Floor 25" },
     ],
   },
+  {
+    mapLabel: "深淵回廊",
+    mapLabelEn: "Abyssal Corridor",
+    label: "26F",
+    labelEn: "26F",
+    presets: [
+      { monsterName: "ダークウィッチ", level: 7777777, location: "26層", locationEn: "Floor 26" },
+      { monsterName: "冥炎のハデス",   level: 7777777, location: "26層", locationEn: "Floor 26" },
+      { monsterName: "BOX",           level: 9999999, location: "26層", locationEn: "Floor 26" },
+    ],
+  },
   // ---- アイスリッジ山 ----
   {
     mapLabel: "アイスリッジ山",


### PR DESCRIPTION
## 変更内容

深淵回廊26Fのモンスタープリセットを追加。

| モンスター | レベル |
|---|---|
| ダークウィッチ | 7,777,777 |
| 冥炎のハデス | 7,777,777 |
| BOX | 9,999,999 |

## 確認事項

- [x] 型チェック通過（`npx tsc --noEmit`）
- [x] 既存エントリの順序変更なし（末尾グループとして追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)