### PR TITLE
feat: 天空回廊の新モンスタープリセット・ペットスキルを追加

### DIFF
--- a/docs/data/pet-skills.json
+++ b/docs/data/pet-skills.json
@@ -3196,5 +3196,167 @@
         "value": 50
       }
     ]
+  },
+  {
+    "name": "BIG BOX",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "DEF",
+        "value": 10000
+      },
+      {
+        "level": 71,
+        "type": "DEF",
+        "value": 100000
+      },
+      {
+        "level": 121,
+        "type": "DEF",
+        "value": 1000000
+      }
+    ]
+  },
+  {
+    "name": "SBB",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "ドロップ率",
+        "value": 1000
+      },
+      {
+        "level": 71,
+        "type": "ドロップ率",
+        "value": 1000
+      },
+      {
+        "level": 121,
+        "type": "ドロップ率",
+        "value": 1000
+      }
+    ]
+  },
+  {
+    "name": "RAINBOW BOX",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "経験値",
+        "value": 1500
+      },
+      {
+        "level": 71,
+        "type": "経験値",
+        "value": 1500
+      },
+      {
+        "level": 121,
+        "type": "経験値",
+        "value": 1500
+      }
+    ]
+  },
+  {
+    "name": "スカイガーディアン",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "VIT%",
+        "value": 100
+      },
+      {
+        "level": 71,
+        "type": "VIT%",
+        "value": 100
+      },
+      {
+        "level": 121,
+        "type": "VIT%",
+        "value": 100
+      },
+      {
+        "level": 181,
+        "type": "DEF%",
+        "value": 300
+      }
+    ]
+  },
+  {
+    "name": "海賊船長ボンゴレ",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "LUCK%",
+        "value": 100
+      },
+      {
+        "level": 71,
+        "type": "DEF%",
+        "value": 100
+      },
+      {
+        "level": 121,
+        "type": "M-DEF%",
+        "value": 100
+      },
+      {
+        "level": 181,
+        "type": "INT%",
+        "value": 300
+      }
+    ]
+  },
+  {
+    "name": "だいこんに見えないだいこん",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "最終INT%",
+        "value": 10
+      },
+      {
+        "level": 71,
+        "type": "最終INT%",
+        "value": 20
+      },
+      {
+        "level": 121,
+        "type": "最終INT%",
+        "value": 30
+      },
+      {
+        "level": 181,
+        "type": "最終INT%",
+        "value": 40
+      }
+    ]
+  },
+  {
+    "name": "ハイパーギガント",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "最終VIT%",
+        "value": 25
+      },
+      {
+        "level": 71,
+        "type": "最終VIT%",
+        "value": 25
+      },
+      {
+        "level": 121,
+        "type": "最終VIT%",
+        "value": 50
+      }
+    ]
   }
 ]

--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -283,7 +283,29 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
     label: "天空回廊",
     labelEn: "Sky Corridor",
     presets: [
-      { monsterName: "スカイガーディアン", level: 1100, location: "天空回廊・100の倍数フロア", locationEn: "Sky Corridor - Floors divisible by 100" },
+      { monsterName: "BIG BOX",          level: 10100, location: "天空回廊", locationEn: "Sky Corridor" },
+      { monsterName: "SBB",              level: 10100, location: "天空回廊", locationEn: "Sky Corridor" },
+      { monsterName: "RAINBOW BOX",      level: 10100, location: "天空回廊", locationEn: "Sky Corridor" },
+      { monsterName: "スカイガーディアン", level: 20000, location: "天空回廊・100Fごと", locationEn: "Sky Corridor - Every 100 Floors" },
+    ],
+  },
+  {
+    mapLabel: "天空回廊",
+    mapLabelEn: "Sky Corridor",
+    label: "天空宝物庫",
+    labelEn: "Sky Treasury",
+    presets: [
+      { monsterName: "虹ペリカンEXP", level: 10000, location: "天空宝物庫", locationEn: "Sky Treasury" },
+    ],
+  },
+  {
+    mapLabel: "天空回廊",
+    mapLabelEn: "Sky Corridor",
+    label: "天空大航海",
+    labelEn: "Sky Voyage",
+    presets: [
+      { monsterName: "海賊船",         level: 1009900, location: "天空大航海", locationEn: "Sky Voyage" },
+      { monsterName: "海賊船長ボンゴレ", level: 1009900, location: "天空大航海", locationEn: "Sky Voyage" },
     ],
   },
   {


### PR DESCRIPTION
## 変更内容

### enemyPresets.ts

| モンスター | レベル（最低） | 場所 |
|---|---|---|
| BIG BOX | 10,100 | 天空回廊 |
| SBB | 10,100 | 天空回廊 |
| RAINBOW BOX | 10,100 | 天空回廊 |
| スカイガーディアン | 20,000 | 天空回廊・100Fごと（旧1,100から更新） |
| 虹ペリカンEXP | 10,000 | 天空宝物庫（新グループ） |
| 海賊船 | 1,009,900 | 天空大航海（新グループ） |
| 海賊船長ボンゴレ | 1,009,900 | 天空大航海（新グループ） |

### pet-skills.json

| モンスター | 段階数 | 備考 |
|---|---|---|
| BIG BOX | 3段階 | 4段階目未判明 |
| SBB | 3段階 | 4段階目未判明 |
| RAINBOW BOX | 3段階 | 4段階目未判明 |
| スカイガーディアン | 4段階 | 完全 |
| 海賊船長ボンゴレ | 4段階 | 完全 |
| だいこんに見えないだいこん | 4段階 | 完全（monsters.json登録は後回し） |
| ハイパーギガント | 3段階 | 4段階目未判明（monsters.json登録は後回し） |

## 確認事項

- [x] 型チェック通過（`npx tsc --noEmit`）
- [x] 既存エントリの順序変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)