### PR TITLE
fix(skyCorridor): フロア入力を先頭に移動し「目標フロア」に改称

### DIFF
--- a/src/components/SkyCorridorCalculator.tsx
+++ b/src/components/SkyCorridorCalculator.tsx
@@ -859,6 +859,34 @@ export function SkyCorridorCalculator({
       <div className="space-y-6 lg:space-y-2">
         <div className="bg-white rounded-3xl shadow-lg shadow-gray-200/50 p-6 lg:p-4 space-y-5 lg:space-y-3">
 
+          {/* フロア入力 */}
+          <div className="space-y-1.5">
+            <label className="block text-sm lg:text-xs font-medium text-gray-600">
+              {t("displayFloor")}
+            </label>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={(() => {
+                const n = parseInt(skyFloor, 10);
+                return isNaN(n) ? "" : n.toLocaleString();
+              })()}
+              onChange={(e) => {
+                const raw = e.target.value.replace(/[^0-9]/g, "");
+                setSkyFloor(raw);
+              }}
+              onBlur={(e) => {
+                const raw = e.target.value.replace(/[^0-9]/g, "");
+                const clamped = Math.max(1, parseInt(raw || "1") || 1);
+                setSkyFloor(String(clamped));
+              }}
+              placeholder="1"
+              className="w-full px-4 py-3 lg:py-2 bg-white border border-gray-200 rounded-xl text-lg lg:text-base font-medium text-gray-800 placeholder:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+            />
+          </div>
+
+          <div className="border-t border-gray-100" />
+
           {/* モード切り替えタブ */}
           <div className="flex rounded-xl overflow-hidden border border-gray-200 text-xs font-medium">
             {(["endurance", "attack"] as const).map((mode) => (
@@ -952,33 +980,6 @@ export function SkyCorridorCalculator({
             </div>
           )}
 
-          <div className="border-t border-gray-100" />
-
-          {/* フロア入力 */}
-          <div className="space-y-1.5">
-            <label className="block text-sm lg:text-xs font-medium text-gray-600">
-              {t("displayFloor")}
-            </label>
-            <input
-              type="text"
-              inputMode="numeric"
-              value={(() => {
-                const n = parseInt(skyFloor, 10);
-                return isNaN(n) ? "" : n.toLocaleString();
-              })()}
-              onChange={(e) => {
-                const raw = e.target.value.replace(/[^0-9]/g, "");
-                setSkyFloor(raw);
-              }}
-              onBlur={(e) => {
-                const raw = e.target.value.replace(/[^0-9]/g, "");
-                const clamped = Math.max(1, parseInt(raw || "1") || 1);
-                setSkyFloor(String(clamped));
-              }}
-              placeholder="1"
-              className="w-full px-4 py-3 lg:py-2 bg-white border border-gray-200 rounded-xl text-lg lg:text-base font-medium text-gray-800 placeholder:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
-            />
-          </div>
         </div>
 
         {/* サマリー（耐久モード時のみ） */}

--- a/src/i18n/locales/en/skyCorridor.json
+++ b/src/i18n/locales/en/skyCorridor.json
@@ -13,7 +13,7 @@
   "off": "OFF",
   "syncModeManual": "Manual",
   "syncModeSim": "Equipment",
-  "displayFloor": "Floor",
+  "displayFloor": "Target Floor",
   "lukEvasionLabel": "LUK (for evasion)",
   "overallMaxFloor": "Overall Max Floor",
   "sectionPhysical": "Physical Top 8",

--- a/src/i18n/locales/ja/skyCorridor.json
+++ b/src/i18n/locales/ja/skyCorridor.json
@@ -13,7 +13,7 @@
   "off": "OFF",
   "syncModeManual": "手動入力",
   "syncModeSim": "装備設定",
-  "displayFloor": "フロア",
+  "displayFloor": "目標フロア",
   "lukEvasionLabel": "LUK（回避判定用）",
   "overallMaxFloor": "全体限界フロア",
   "sectionPhysical": "物理攻撃上位8体",


### PR DESCRIPTION
## 変更内容
- フロア入力欄をカードの最上部（モード切り替えタブの前）に移動
- ラベルを「フロア」→「目標フロア」に変更（ja/en両対応）

## 確認事項
- [ ] 天空回廊タブを開いてフロア入力が一番上に表示されること
- [ ] ラベルが「目標フロア」になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)