### PR TITLE
fix(skyCorridor): 無効化済み時も必要DEF/MDEFを正しく表示

### DIFF
--- a/src/components/SkyCorridorCalculator.tsx
+++ b/src/components/SkyCorridorCalculator.tsx
@@ -6,7 +6,6 @@ import { scaleMonster } from "../utils/monsterScaling";
 import { formatHitCount } from "../utils/formatNumber";
 import {
   canNullifyDamage,
-  calcAdditionalDefNeeded,
   calcDamage,
 } from "../utils/defenseCalc";
 import {
@@ -694,9 +693,13 @@ export function SkyCorridorCalculator({
     const nullifiedNow = canNullifyDamage(enemyStat, effectiveDef, effectiveMdef, isPhysical);
     const maxNullifyFloor = calcMaxNullifyFloor(base, effectiveDef, effectiveMdef);
 
-    const additional = calcAdditionalDefNeeded(enemyStat, effectiveDef, effectiveMdef, isPhysical);
-    const requiredDef = effectiveDef + additional.additionalDef;
-    const requiredMdef = effectiveMdef + additional.additionalMdef;
+    const threshold = enemyStat * 1.75;
+    const requiredDef = isPhysical
+      ? Math.max(0, Math.ceil(threshold - effectiveMdef / 10))
+      : Math.max(0, Math.ceil((threshold - effectiveMdef) * 10));
+    const requiredMdef = isPhysical
+      ? Math.max(0, Math.ceil((threshold - effectiveDef) * 10))
+      : Math.max(0, Math.ceil(threshold - effectiveDef / 10));
 
     let hitsToSurvive: { worst: number; best: number } | null = null;
     if (playerHp > 0) {


### PR DESCRIPTION
## 問題

天空回廊シミュの耐久モードで、プレイヤーのDEF/MDEFがそのモンスターを無効化するのに十分な場合でも、必要DEF/MDEF列に**プレイヤー自身の現在値**が表示されていた。

## 原因

```typescript
// 修正前
const additional = calcAdditionalDefNeeded(enemyStat, effectiveDef, effectiveMdef, isPhysical);
const requiredDef = effectiveDef + additional.additionalDef;  // 無効化済み → +0 → effectiveDef をそのまま表示
```

`calcAdditionalDefNeeded` は無効化済みの場合 `additionalDef = 0` を返すため、`effectiveDef + 0 = effectiveDef`（プレイヤー値）になっていた。

## 修正

threshold（`enemyStat × 1.75`）から直接逆算するよう変更：

- 物理: `requiredDef = max(0, ceil(threshold - MDEF/10))`
- 魔法: `requiredMdef = max(0, ceil(threshold - DEF/10))`

無効化済み・不足どちらの場合でも常に「このモンスターを無効化するために必要な最小DEF/MDEF」を表示するようになった。

## 確認事項

- [x] 型チェック通過（`npx tsc --noEmit`）
- [x] 不要になった `calcAdditionalDefNeeded` インポートを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)