### PR TITLE
feat(statusSim): ステータス天晶を振り分けポイントに追加

### DIFF
--- a/src/components/SimConfigPanel.tsx
+++ b/src/components/SimConfigPanel.tsx
@@ -947,6 +947,7 @@ function InputPanel({ cfg, setField, reset }: { cfg: SimConfig; setField: SimSet
 
   function maxAllPoints() {
     setField("johaneCount", 1000);
+    setField("statusTenshouCount", 1000);
   }
 
   function maxAllEquip() {
@@ -1110,6 +1111,8 @@ function InputPanel({ cfg, setField, reset }: { cfg: SimConfig; setField: SimSet
                 onChange={(v) => setField("johaneCount", v)} />
               <NumInput label={t("johanneAltar")} value={cfg.johanneAltarCount} max={1000}
                 onChange={(v) => setField("johanneAltarCount", v)} />
+              <NumInput label={t("statusTenshou")} value={cfg.statusTenshouCount} max={1000}
+                onChange={(v) => setField("statusTenshouCount", v)} />
             </div>
             <div className="grid grid-cols-2 gap-2 text-xs bg-gray-50 rounded-lg px-3 py-1.5">
               <div>{t("availablePoints")}<br /><span className="font-mono font-semibold text-gray-700">{available.toLocaleString()}</span></div>

--- a/src/hooks/useSharedSimConfig.ts
+++ b/src/hooks/useSharedSimConfig.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SIM_CONFIG: SimConfig = {
   hasCosmoCube: false,
   johaneCount: 0,
   johanneAltarCount: 0,
+  statusTenshouCount: 0,
   allocVit: 0, allocSpd: 0, allocAtk: 0, allocInt: 0,
   allocDef: 0, allocMdef: 0, allocLuck: 0,
   equipWeapon: "", enhWeapon: 1100,

--- a/src/i18n/locales/en/status.json
+++ b/src/i18n/locales/en/status.json
@@ -17,6 +17,7 @@
   "allocationSection": "Stat Points",
   "johannePen": "Johane's Quill Pen (Avail pts×1%/ea)",
   "johanneAltar": "Johanne's Altar (Quill Pen effect+0.2%/ea)",
+  "statusTenshou": "Status Crystal (+10,000pt/ea)",
   "availablePoints": "Available Points",
   "perStatLimit": "Per-Stat Limit",
   "allocationPoints": "Allocation Points",

--- a/src/i18n/locales/ja/status.json
+++ b/src/i18n/locales/ja/status.json
@@ -17,6 +17,7 @@
   "allocationSection": "振り分けポイント",
   "johannePen": "ヨハネの羽ペン (利用可能ポイント×1%/個)",
   "johanneAltar": "ヨハネの祭壇 (羽ペン効果+0.2%/個)",
+  "statusTenshou": "ステータス天晶 (+10,000pt/個)",
   "availablePoints": "利用可能ポイント",
   "perStatLimit": "1ステータス上限",
   "allocationPoints": "割り振りポイント",

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -130,6 +130,7 @@ export interface SimConfig extends Record<string, unknown> {
   hasCosmoCube: boolean;
   johaneCount: number;
   johanneAltarCount: number;
+  statusTenshouCount: number;    // ステータス天晶（+10000pt/個、ヨハネ効果なし、上限1000）
   // ステータス割り振り
   allocVit: number;
   allocSpd: number;

--- a/src/utils/statusCalc.ts
+++ b/src/utils/statusCalc.ts
@@ -25,7 +25,8 @@ export function getAvailablePoints(cfg: SimConfig): number {
     : 0;
   const cosmoCubeBonus = cfg.hasCosmoCube ? cfg.reinCount * 10000 : 0;
   const subtotal = multiplied + pinnacleBonus + cosmoCubeBonus;
-  return Math.floor(subtotal * (1 + cfg.johaneCount / 100) * (1 + cfg.johanneAltarCount * 0.002));
+  const withJohane = Math.floor(subtotal * (1 + cfg.johaneCount / 100) * (1 + cfg.johanneAltarCount * 0.002));
+  return withJohane + cfg.statusTenshouCount * 10000;
 }
 
 /** 1ステータスへの割り振り上限（天命輪廻ベース） */


### PR DESCRIPTION
## 変更内容

新アイテム「ステータス天晶」をステータスシミュレータの振り分けポイントセクションに追加。

- **効果**: +10,000pt/個（最大1000個 = 最大1,000万pt）
- **ヨハネ効果なし**: ジョハネの羽ペン・祭壇の乗算対象外（計算式でヨハネ計算後に加算）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/types/game.ts` | `SimConfig` に `statusTenshouCount` フィールドを追加 |
| `src/utils/statusCalc.ts` | `getAvailablePoints` でヨハネ計算後に `statusTenshouCount × 10000` を加算 |
| `src/hooks/useSharedSimConfig.ts` | デフォルト値 `statusTenshouCount: 0` を追加 |
| `src/components/SimConfigPanel.tsx` | 「振り分けポイント」セクションに入力欄・MAXボタン対応を追加 |
| `src/i18n/locales/ja/status.json` | 日本語ラベル追加 |
| `src/i18n/locales/en/status.json` | 英語ラベル追加 |

## 確認事項

- [ ] ステータス天晶の個数を入力すると利用可能ポイントが正しく増加する
- [ ] ヨハネの羽ペンを変更してもステータス天晶分のポイントは変化しない
- [ ] MAXボタンで1000個にセットされる
- [ ] 型チェック (`npx tsc --noEmit`) が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)