### PR TITLE
feat(skyCorridor): 階層スキップシミュに操作回数まとめを表示

### DIFF
--- a/src/components/SkyCorridorFloorSkip.tsx
+++ b/src/components/SkyCorridorFloorSkip.tsx
@@ -177,18 +177,21 @@ function SolutionCard({
         <div className="flex items-center justify-center w-8 h-8 rounded-full bg-indigo-100 text-indigo-700 text-sm font-bold flex-shrink-0">
           {idx + 1}
         </div>
-        <div className="flex-1 grid grid-cols-2 sm:grid-cols-5 gap-x-3 gap-y-1 text-sm">
-          <Stat label={t("floorSkip.headers.startFloor")} value={`${sol.startFloor.toLocaleString()}F`} />
-          <Stat label={t("floorSkip.headers.adventurerUsed")} value={`${sol.effectiveAdventurer}`} />
-          <Stat label={t("floorSkip.headers.demonUsed")} value={`${sol.demonUsed}`} />
-          <Stat
-            label={t("floorSkip.headers.cycles")}
-            value={sol.cycles > 0 ? `${sol.cycles}` : "—"}
-          />
-          <Stat
-            label={t("floorSkip.headers.cycleProgress")}
-            value={sol.cycleProgress > 0 ? `+${sol.cycleProgress.toLocaleString()}F` : "—"}
-          />
+        <div className="flex-1 space-y-1">
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-x-3 gap-y-1 text-sm">
+            <Stat label={t("floorSkip.headers.startFloor")} value={`${sol.startFloor.toLocaleString()}F`} />
+            <Stat label={t("floorSkip.headers.adventurerUsed")} value={`${sol.effectiveAdventurer}`} />
+            <Stat label={t("floorSkip.headers.demonUsed")} value={`${sol.demonUsed}`} />
+            <Stat
+              label={t("floorSkip.headers.cycles")}
+              value={sol.cycles > 0 ? `${sol.cycles}` : "—"}
+            />
+            <Stat
+              label={t("floorSkip.headers.cycleProgress")}
+              value={sol.cycleProgress > 0 ? `+${sol.cycleProgress.toLocaleString()}F` : "—"}
+            />
+          </div>
+          <OperationSummaryInline sol={sol} />
         </div>
         <div className="flex flex-col items-end gap-1 flex-shrink-0 ml-2">
           {sol.noGuardian && (
@@ -253,7 +256,6 @@ function DetailBlock({
             {t("floorSkip.cycleSummary", { delta: sol.cycleProgress.toLocaleString() })}
           </p>
         </StepBlock>
-        <OperationSummary sol={sol} />
         <StepBlock
           title={t("floorSkip.stepGoalTitle", { floor: targetFloor.toLocaleString() })}
           accent="goal"
@@ -302,9 +304,6 @@ function DetailBlock({
           <p className="text-sm text-gray-500">{t("floorSkip.noCycleNeeded")}</p>
         </StepBlock>
       )}
-
-      {/* 操作回数まとめ */}
-      <OperationSummary sol={sol} />
 
       {/* STEP 3 到達 */}
       <StepBlock
@@ -487,21 +486,18 @@ function BroughtSummary({
 }
 
 
-function OperationSummary({ sol }: { sol: CycleSolution }) {
+function OperationSummaryInline({ sol }: { sol: CycleSolution }) {
   const initialCount = sol.initial.steps.length;
   const cycleCount = sol.cycles;
   const total = initialCount + cycleCount;
 
   return (
-    <div className="rounded-lg border border-indigo-200 bg-indigo-50/40 px-3 py-2 text-sm">
-      <div className="font-semibold text-indigo-700 mb-1">操作回数まとめ</div>
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 text-gray-700">
-        {initialCount > 0 && (
-          <span>STEP1の手順 <strong>{initialCount}</strong>回</span>
-        )}
-        <span>STEP2のサイクル <strong>{cycleCount}</strong>回</span>
-        <span className="font-bold text-indigo-700">合計 {total}回</span>
-      </div>
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-0 text-xs text-gray-500">
+      {initialCount > 0 && (
+        <span>STEP1の手順 <strong className="text-gray-700">{initialCount}</strong>回</span>
+      )}
+      <span>STEP2のサイクル <strong className="text-gray-700">{cycleCount}</strong>回</span>
+      <span className="font-semibold text-indigo-600">合計 {total}回</span>
     </div>
   );
 }

--- a/src/components/SkyCorridorFloorSkip.tsx
+++ b/src/components/SkyCorridorFloorSkip.tsx
@@ -253,6 +253,7 @@ function DetailBlock({
             {t("floorSkip.cycleSummary", { delta: sol.cycleProgress.toLocaleString() })}
           </p>
         </StepBlock>
+        <OperationSummary sol={sol} />
         <StepBlock
           title={t("floorSkip.stepGoalTitle", { floor: targetFloor.toLocaleString() })}
           accent="goal"
@@ -301,6 +302,9 @@ function DetailBlock({
           <p className="text-sm text-gray-500">{t("floorSkip.noCycleNeeded")}</p>
         </StepBlock>
       )}
+
+      {/* 操作回数まとめ */}
+      <OperationSummary sol={sol} />
 
       {/* STEP 3 到達 */}
       <StepBlock
@@ -482,6 +486,25 @@ function BroughtSummary({
   );
 }
 
+
+function OperationSummary({ sol }: { sol: CycleSolution }) {
+  const initialCount = sol.initial.steps.length;
+  const cycleCount = sol.cycles;
+  const total = initialCount + cycleCount;
+
+  return (
+    <div className="rounded-lg border border-indigo-200 bg-indigo-50/40 px-3 py-2 text-sm">
+      <div className="font-semibold text-indigo-700 mb-1">操作回数まとめ</div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 text-gray-700">
+        {initialCount > 0 && (
+          <span>STEP1の手順 <strong>{initialCount}</strong>回</span>
+        )}
+        <span>STEP2のサイクル <strong>{cycleCount}</strong>回</span>
+        <span className="font-bold text-indigo-700">合計 {total}回</span>
+      </div>
+    </div>
+  );
+}
 
 function CycleSampleCard({
   sol,

--- a/src/utils/skyCorridorFloorSkip.ts
+++ b/src/utils/skyCorridorFloorSkip.ts
@@ -217,7 +217,7 @@ export function enumerateFloorSkip(input: FloorSkipInput): CycleSolution[] {
             cycleProgress: delta,
             placedDuringCycle: 0,
             effectiveAdventurer: brought,
-            totalOperations: initial.steps.length + cycles * 2,
+            totalOperations: initial.steps.length + cycles,
             initial,
           });
         }

--- a/src/utils/skyCorridorFloorSkip.ts
+++ b/src/utils/skyCorridorFloorSkip.ts
@@ -252,12 +252,12 @@ export function enumerateFloorSkip(input: FloorSkipInput): CycleSolution[] {
   }
 
   const arr = Array.from(best.values());
-  // ソート: 操作数が少ない順 → サイクル数が少ない順 → スタートF が小さい順
+  // ソート: 合計回数少ない順 → STEP1（初動手順）少ない順 → STEP2（サイクル）少ない順
   arr.sort(
     (a, b) =>
       a.totalOperations - b.totalOperations ||
-      a.cycles - b.cycles ||
-      a.startFloor - b.startFloor
+      a.initial.steps.length - b.initial.steps.length ||
+      a.cycles - b.cycles
   );
   return arr;
 }


### PR DESCRIPTION
## Summary
- 詳細展開時に「操作回数まとめ」ボックスを追加（STEP1手順X回・STEP2サイクルY回・合計Z回）
- ソート順を `initialSteps + cycles * 2` から `initialSteps + cycles` に修正し、表示するZ回と一致させた

## 確認事項
- [ ] 通常ルート（初動あり）で手順・サイクル・合計が正しく表示される
- [ ] ガーディアンなしルートでサイクル・合計のみ表示される（STEP1行は非表示）
- [ ] 合計の少ない順に並んでいる

🤖 Generated with [Claude Code](https://claude.com/claude-code)