### PR TITLE
feat(data): アルティメットアヌビス追加・天空砂漠神プリセット・ペットスキル更新

### DIFF
--- a/docs/data/monsters.json
+++ b/docs/data/monsters.json
@@ -2300,5 +2300,22 @@
     "captureRate": 0,
     "exp": 0,
     "gold": 0
+  },
+  {
+    "name": "アルティメットアヌビス",
+    "level": 0,
+    "element": "光",
+    "attackType": "物理",
+    "vit": 3610,
+    "spd": 510,
+    "atk": 910,
+    "int": 91,
+    "def": 510,
+    "mdef": 510,
+    "luck": 510,
+    "mov": 61,
+    "captureRate": 0.1,
+    "exp": 9311400,
+    "gold": 3000000
   }
 ]

--- a/docs/data/pet-skills.json
+++ b/docs/data/pet-skills.json
@@ -2980,12 +2980,12 @@
       {
         "level": 800,
         "type": "DEF%",
-        "value": null
+        "value": 200
       },
       {
         "level": 1200,
         "type": "DEF%",
-        "value": null
+        "value": 250
       }
     ]
   },
@@ -3215,6 +3215,11 @@
         "level": 121,
         "type": "DEF",
         "value": 1000000
+      },
+      {
+        "level": 181,
+        "type": "DEF",
+        "value": 10000000
       }
     ]
   },
@@ -3356,6 +3361,37 @@
         "level": 121,
         "type": "最終VIT%",
         "value": 50
+      },
+      {
+        "level": 181,
+        "type": "最終VIT%",
+        "value": 100
+      }
+    ]
+  },
+  {
+    "name": "アルティメットアヌビス",
+    "pattern": 1,
+    "skills": [
+      {
+        "level": 31,
+        "type": "ATK",
+        "value": 1000000
+      },
+      {
+        "level": 71,
+        "type": "ATK",
+        "value": 1000000
+      },
+      {
+        "level": 121,
+        "type": "ATK",
+        "value": 1000000
+      },
+      {
+        "level": 181,
+        "type": "ATK",
+        "value": 7000000
       }
     ]
   }

--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -320,6 +320,15 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
     ],
   },
   {
+    mapLabel: "天空回廊",
+    mapLabelEn: "Sky Corridor",
+    label: "天空砂漠神",
+    presets: [
+      { monsterName: "アルティメットアヌビス", level: 10009900, location: "天空砂漠神" },
+      { monsterName: "禁域のアヌビシュ",       level: 10009900, location: "天空砂漠神" },
+    ],
+  },
+  {
     mapLabel: "アイスリッジ山",
     mapLabelEn: "Ice Ridge Mtn",
     label: "アイスリッジ氷葬",


### PR DESCRIPTION
## 変更内容

- **新モンスター**: アルティメットアヌビス（光/物理、天空砂漠神エリア）をmonsters.jsonに追加
- **プリセット**: 天空回廊 > 天空砂漠神を追加（アルティメットアヌビス・禁域のアヌビシュ、Lv.10,009,900）
- **ペットスキル追加**: アルティメットアヌビス（ATK+1,000,000/+1,000,000/+1,000,000/+7,000,000）
- **ペットスキル更新**:
  - 鉄壁要塞パルテノン: Lv.800→DEF+200%、Lv.1200→DEF+250%（nullを実値に更新）
  - BIG BOX: Lv.1200（DEF+10,000,000）追加
  - ハイパーギガント: Lv.1200（最終VIT+100%）追加

## 確認事項

- [ ] ダメージ計算機でアルティメットアヌビスが選択できる
- [ ] 天空回廊 > 天空砂漠神プリセットが表示される
- [ ] ペットシミュレータで更新スキルが正しく反映される
- [ ] 型エラーなし（`npx tsc --noEmit`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)