### PR TITLE
feat(data): 深淵回廊27F・武器・アクセ・モンスター追加

### DIFF
--- a/docs/data/accessories.json
+++ b/docs/data/accessories.json
@@ -490,5 +490,58 @@
       }
     ],
     "nameEn": "Band of Seven Principles"
+  },
+  {
+    "name": "風律瓶",
+    "maxLevel": 10,
+    "effects": [
+      {
+        "type": "ATK%",
+        "value": 200,
+        "scalePercent": 2
+      },
+      {
+        "type": "SPD%",
+        "value": 200,
+        "scalePercent": 2
+      }
+    ],
+    "nameEn": null
+  },
+  {
+    "name": "ルクスチャーム",
+    "maxLevel": 10,
+    "effects": [
+      {
+        "type": "LUCK%",
+        "value": 300,
+        "scalePercent": 3
+      }
+    ],
+    "nameEn": null
+  },
+  {
+    "name": "リジェネコア",
+    "maxLevel": 1,
+    "effects": [
+      {
+        "type": "HP回復",
+        "value": 5,
+        "scalePercent": 0
+      }
+    ],
+    "nameEn": null
+  },
+  {
+    "name": "学命書",
+    "maxLevel": 2000,
+    "effects": [
+      {
+        "type": "経験値",
+        "value": 100,
+        "scalePercent": 1
+      }
+    ],
+    "nameEn": null
   }
 ]

--- a/docs/data/equipment.json
+++ b/docs/data/equipment.json
@@ -1307,5 +1307,22 @@
     "special": "2体攻撃\n攻撃範囲増（中）",
     "order": 760,
     "nameEn": "Twin Blades of Ruin"
+  },
+  {
+    "name": "天空剣ソラシド",
+    "slot": "武器",
+    "series": null,
+    "material": null,
+    "vit": 0,
+    "spd": 0,
+    "atk": 6789000,
+    "int": 0,
+    "def": 0,
+    "mdef": 0,
+    "luck": 0,
+    "mov": 0,
+    "special": "攻撃範囲増（小）",
+    "order": 770,
+    "nameEn": "Celestial Sword Sorachido"
   }
 ]

--- a/docs/data/monsters.json
+++ b/docs/data/monsters.json
@@ -2317,5 +2317,39 @@
     "captureRate": 0.1,
     "exp": 9311400,
     "gold": 3000000
+  },
+  {
+    "name": "だいこんに見えないだいこん",
+    "level": 0,
+    "element": "木",
+    "attackType": "魔弾",
+    "vit": 910,
+    "spd": 215,
+    "atk": 115,
+    "int": 415,
+    "def": 315,
+    "mdef": 515,
+    "luck": 415,
+    "mov": 0,
+    "captureRate": 1,
+    "exp": 0,
+    "gold": 0
+  },
+  {
+    "name": "ハイパーギガント",
+    "level": 0,
+    "element": "火",
+    "attackType": "物理",
+    "vit": 1210,
+    "spd": 333,
+    "atk": 333,
+    "int": 333,
+    "def": 333,
+    "mdef": 333,
+    "luck": 333,
+    "mov": 39,
+    "captureRate": 1,
+    "exp": 0,
+    "gold": 0
   }
 ]

--- a/src/data/enemyPresets.ts
+++ b/src/data/enemyPresets.ts
@@ -198,6 +198,16 @@ export const enemyPresetGroups: EnemyPresetGroup[] = [
       { monsterName: "BOX",           level: 9999999, location: "26層", locationEn: "Floor 26" },
     ],
   },
+  {
+    mapLabel: "深淵回廊",
+    mapLabelEn: "Abyssal Corridor",
+    label: "27F",
+    labelEn: "27F",
+    presets: [
+      { monsterName: "イグニス・シスター", level: 500000, location: "27層", locationEn: "Floor 27" },
+      { monsterName: "オルド・クラウセス", level: 500000, location: "27層", locationEn: "Floor 27" },
+    ],
+  },
   // ---- アイスリッジ山 ----
   {
     mapLabel: "アイスリッジ山",


### PR DESCRIPTION
## 変更内容

- **深淵回廊27F プリセット追加**
  - イグニス・シスター HP 500,000（27層）
  - オルド・クラウセス HP 500,000（27層）

- **武器追加**
  - 天空剣ソラシド（ATK 6,789,000・強化不可・攻撃範囲増（小））

- **アクセサリー追加**
  - 風律瓶（ATK%+200 / SPD%+200、maxLv.10、暫定値あり）
  - ルクスチャーム（LUCK%+300、maxLv.10）
  - リジェネコア（HP回復+5%、maxLv.1）
  - 学命書（経験値+100%、maxLv.2000、暫定値あり）

- **モンスター追加**（Wikiとの差分解消）
  - だいこんに見えないだいこん（木/魔弾）
  - ハイパーギガント（火/物理）

## 確認事項

- [ ] 風律瓶・学命書の`?`マーク付きデータ（maxLevel・scalePercent）は暫定値。確定次第要修正
- [ ] だいこんに見えないだいこん・ハイパーギガントの`exp`/`gold`は0（Wiki未記載）。確定次第要修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)